### PR TITLE
[2.x] Optional value column + HasWeight capability + score()/averageOf()

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,47 @@ $post->disengage(Reaction::Bookmark);
 
 Passing a Verb that does not belong to the configured enum throws an `UnknownEngagementType` exception.
 
+### Weighted Verbs & Engagement Values
+
+Engagements can carry an optional numeric **value** (a nullable signed decimal column). A Verb opts in by implementing `Cjmellor\Engageify\Contracts\HasWeight`, which derives a fixed weight per case — for example an upvote is `+1` and a downvote `-1`:
+
+```php
+use Cjmellor\Engageify\Contracts\EngagementType;
+use Cjmellor\Engageify\Contracts\HasWeight;
+
+enum Vote: string implements EngagementType, HasWeight
+{
+    case Up = 'up';
+    case Down = 'down';
+
+    public function weight(): int
+    {
+        return match ($this) {
+            self::Up => 1,
+            self::Down => -1,
+        };
+    }
+}
+```
+
+When a `HasWeight` Verb is engaged its weight is stored automatically. You cannot pass your own value to a `HasWeight` Verb (or to a binary Verb) — doing so throws an `EngagementValueException`. Binary Verbs store `null`.
+
+```php
+$post->engage(Vote::Up);   // stores the derived value 1
+$post->engage(Vote::Down); // stores the derived value -1
+```
+
+Read the value back per Verb with `score()` (a `SUM`) and `averageOf()` (an `AVG`):
+
+```php
+$post->score(Vote::Up);     // total stored weight for upvotes
+$post->averageOf(Vote::Up); // mean stored weight for upvotes
+```
+
+Both throw an `EngagementValueException` on a binary Verb, which carries no value to aggregate.
+
+> Upgrading from v1? The `value` column ships as an additive migration — publish it with `php artisan vendor:publish --tag="engageify-migrations"` and run `php artisan migrate`.
+
 ### "Like" Specific Reaction
 
 The "like" reaction has some additional functionality. A "like" can be "unliked". This shouldn't be confused with a "dislike" as a "dislike" counts as an engagement, whereas an "unlike" is deleting the engagement.

--- a/database/migrations/2026_05_31_000000_add_value_to_engagements_table.php
+++ b/database/migrations/2026_05_31_000000_add_value_to_engagements_table.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('engagements', function (Blueprint $table): void {
+            $table->decimal(column: 'value', total: 8, places: 2)->nullable();
+        });
+    }
+};

--- a/src/Concerns/HasEngagements.php
+++ b/src/Concerns/HasEngagements.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace Cjmellor\Engageify\Concerns;
 
 use Cjmellor\Engageify\Contracts\EngagementType;
+use Cjmellor\Engageify\Contracts\HasWeight;
 use Cjmellor\Engageify\Enums\EngagementTypes;
 use Cjmellor\Engageify\Events\Disengaged;
 use Cjmellor\Engageify\Events\Engaged;
+use Cjmellor\Engageify\Exceptions\EngagementValueException;
 use Cjmellor\Engageify\Exceptions\UserCannotEngageException;
 use Cjmellor\Engageify\Models\Engagement;
 use Cjmellor\Engageify\Support\TypeResolver;
@@ -77,7 +79,7 @@ trait HasEngagements
         return $this->getEngagementCount(type: TypeResolver::resolve(value: EngagementTypes::Downvote->value), showUsers: $showUsers);
     }
 
-    public function engage(EngagementType $type): Model
+    public function engage(EngagementType $type, int|float|null $value = null): Model
     {
         $type = TypeResolver::ensure(type: $type);
 
@@ -94,11 +96,30 @@ trait HasEngagements
         $engagement = $this->engagements()->create([
             'user_id' => auth()->id(),
             'type' => $type,
+            'value' => $this->resolveEngagementValue(type: $type, value: $value),
         ]);
 
         event(new Engaged(actor: auth()->user(), engageable: $this, type: $type, engagement: $engagement));
 
         return $engagement;
+    }
+
+    public function score(EngagementType $type): float
+    {
+        $type = TypeResolver::ensure(type: $type);
+
+        throw_unless($this->engagementCarriesValue(type: $type), EngagementValueException::notAvailable(type: $type));
+
+        return (float) $this->engagements()->whereType($type)->sum(column: 'value');
+    }
+
+    public function averageOf(EngagementType $type): float
+    {
+        $type = TypeResolver::ensure(type: $type);
+
+        throw_unless($this->engagementCarriesValue(type: $type), EngagementValueException::notAvailable(type: $type));
+
+        return (float) $this->engagements()->whereType($type)->avg(column: 'value');
     }
 
     public function disengage(EngagementType $type): void
@@ -116,6 +137,18 @@ trait HasEngagements
         return $this->engagements()
             ->whereType($type)
             ->count();
+    }
+
+    protected function resolveEngagementValue(EngagementType $type, int|float|null $value): int|float|null
+    {
+        throw_unless($value === null, EngagementValueException::notAccepted(type: $type));
+
+        return $type instanceof HasWeight ? $type->weight() : null;
+    }
+
+    protected function engagementCarriesValue(EngagementType $type): bool
+    {
+        return $type instanceof HasWeight;
     }
 
     protected function hasEngagedWithType(EngagementType $type): bool

--- a/src/Contracts/HasWeight.php
+++ b/src/Contracts/HasWeight.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cjmellor\Engageify\Contracts;
+
+interface HasWeight
+{
+    public function weight(): int|float;
+}

--- a/src/Exceptions/EngagementValueException.php
+++ b/src/Exceptions/EngagementValueException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cjmellor\Engageify\Exceptions;
+
+use Cjmellor\Engageify\Contracts\EngagementType;
+use Exception;
+
+class EngagementValueException extends Exception
+{
+    public static function notAccepted(EngagementType $type): self
+    {
+        return new self(message: 'The engagement type ['.$type::class.'::'.$type->name.'] does not accept a caller-supplied value.');
+    }
+
+    public static function notAvailable(EngagementType $type): self
+    {
+        return new self(message: 'The engagement type ['.$type::class.'::'.$type->name.'] is binary and carries no value.');
+    }
+}

--- a/src/Models/Engagement.php
+++ b/src/Models/Engagement.php
@@ -32,6 +32,7 @@ class Engagement extends Model
     {
         return [
             'type' => config(key: 'engageify.types'),
+            'value' => 'decimal:2',
         ];
     }
 }

--- a/tests/Concerns/EngagementValueTest.php
+++ b/tests/Concerns/EngagementValueTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+use Cjmellor\Engageify\Exceptions\EngagementValueException;
+use Cjmellor\Engageify\Tests\Fixtures\Enums\Reaction;
+use Cjmellor\Engageify\Tests\Fixtures\Enums\Vote;
+use Illuminate\Database\Eloquent\Model;
+
+beforeEach(function (): void {
+    config(['engageify.types' => Vote::class]);
+    config(['engageify.allow_multiple_engagements' => true]);
+
+    $this->actingAs($this->user);
+});
+
+test('a HasWeight Verb engages with its derived weight', function (): void {
+    $this->user->engage(Vote::Up);
+    $this->user->engage(Vote::Down);
+
+    expect((float) $this->user->engagements()->where('type', Vote::Up->value)->first()->value)->toBe(1.0)
+        ->and((float) $this->user->engagements()->where('type', Vote::Down->value)->first()->value)->toBe(-1.0);
+});
+
+test('a binary Verb stores a null value', function (): void {
+    config(['engageify.types' => Reaction::class]);
+
+    $this->user->engage(Reaction::Bookmark);
+
+    expect($this->user->engagements()->first()->value)->toBeNull();
+});
+
+test('engage() throws when an explicit value is passed to a HasWeight Verb', function (): void {
+    expect(fn (): Model => $this->user->engage(Vote::Up, 5))
+        ->toThrow(exception: EngagementValueException::class);
+});
+
+test('engage() throws when an explicit value is passed to a binary Verb', function (): void {
+    config(['engageify.types' => Reaction::class]);
+
+    expect(fn (): Model => $this->user->engage(Reaction::Bookmark, 5))
+        ->toThrow(exception: EngagementValueException::class);
+});
+
+test('score() sums the value across a Verb\'s engagements', function (): void {
+    $this->user->engage(Vote::Up);
+    $this->user->engage(Vote::Up);
+    $this->user->engage(Vote::Down);
+
+    expect($this->user->score(Vote::Up))->toBe(2.0)
+        ->and($this->user->score(Vote::Down))->toBe(-1.0);
+});
+
+test('averageOf() averages the value across a Verb\'s engagements', function (): void {
+    $this->user->engage(Vote::Up);
+    $this->user->engage(Vote::Up);
+    $this->user->engage(Vote::Down);
+
+    expect($this->user->averageOf(Vote::Up))->toBe(1.0)
+        ->and($this->user->averageOf(Vote::Down))->toBe(-1.0);
+});
+
+test('score() throws on a binary Verb', function (): void {
+    config(['engageify.types' => Reaction::class]);
+
+    expect(fn (): float => $this->user->score(Reaction::Bookmark))
+        ->toThrow(exception: EngagementValueException::class);
+});
+
+test('averageOf() throws on a binary Verb', function (): void {
+    config(['engageify.types' => Reaction::class]);
+
+    expect(fn (): float => $this->user->averageOf(Reaction::Bookmark))
+        ->toThrow(exception: EngagementValueException::class);
+});

--- a/tests/Fixtures/Enums/Vote.php
+++ b/tests/Fixtures/Enums/Vote.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cjmellor\Engageify\Tests\Fixtures\Enums;
+
+use Cjmellor\Engageify\Contracts\EngagementType;
+use Cjmellor\Engageify\Contracts\HasWeight;
+
+enum Vote: string implements EngagementType, HasWeight
+{
+    case Up = 'up';
+    case Down = 'down';
+
+    public function weight(): int
+    {
+        return match ($this) {
+            self::Up => 1,
+            self::Down => -1,
+        };
+    }
+}


### PR DESCRIPTION
Implements #29.

## What

- Nullable signed `decimal(8,2)` `value` column on `engagements` (additive migration).
- `HasWeight` capability interface (`weight(): int|float`). Weighted Verbs derive a fixed, non-overridable value; binary Verbs store `null`; passing a caller-supplied value to either throws `EngagementValueException`.
- `engage()` gains an optional `int|float|null $value` (reserved for future caller-supplied-value capabilities).
- Per-Verb reads `score()` (SUM) and `averageOf()` (AVG), both throwing on binary Verbs rather than returning a misleading `0`.

## Acceptance criteria

- [x] `value` column is a nullable signed decimal; binary Verbs store `null`
- [x] A `HasWeight` Verb engages with its derived weight; passing an explicit value to a `HasWeight` or binary Verb throws
- [x] `score()`/`averageOf()` compute over `value`; both throw for binary Verbs
- [x] `engage()` accepts an optional value used only by caller-supplied-value capabilities
- [x] 100% code + type coverage

Full suite green: 38 tests / 61 assertions, 100% code + type coverage, larastan level 5 clean, Pint + Rector clean.

See ADR-0003 (engagements carry an optional value).