### PR TITLE
[2.x] Exclusive Groups: atomic vote flip, toggle-off, netScore()/breakdown()

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,50 @@ Both throw an `EngagementValueException` on a binary Verb, which carries no valu
 
 > Upgrading from v1? The `value` column ships as an additive migration — publish it with `php artisan vendor:publish --tag="engageify-migrations"` and run `php artisan migrate`.
 
+### Exclusive Groups (vote-style)
+
+For mutually-exclusive Verbs — upvote/downvote, or a single-choice reaction — implement `Cjmellor\Engageify\Contracts\Exclusive` and return a shared `group()` key. Several independent Groups can live in one enum:
+
+```php
+use Cjmellor\Engageify\Contracts\EngagementType;
+use Cjmellor\Engageify\Contracts\Exclusive;
+use Cjmellor\Engageify\Contracts\HasWeight;
+
+enum Vote: string implements EngagementType, Exclusive, HasWeight
+{
+    case Up = 'up';
+    case Down = 'down';
+
+    public function group(): string
+    {
+        return 'vote';
+    }
+
+    public function weight(): int
+    {
+        return match ($this) {
+            self::Up => 1,
+            self::Down => -1,
+        };
+    }
+}
+```
+
+Recording an Exclusive Verb atomically clears any existing engagement by the same user whose Verb shares the group, then records the new one — so a user can never hold two members of a group at once, even under concurrent requests:
+
+```php
+$post->engage(Vote::Down); // down
+$post->engage(Vote::Up);   // switches: down removed, up recorded (one transaction)
+$post->engage(Vote::Up);   // re-recording the active member toggles it off
+```
+
+Switching fires a `Disengaged` event for the cleared member and an `Engaged` event for the new one. Read a Group with `netScore()` (summed weights — a Reddit-style score) and `breakdown()` (per-member counts — handy for a reaction bar):
+
+```php
+$post->netScore('vote');   // e.g. 42
+$post->breakdown('vote');  // ['up' => 50, 'down' => 8]
+```
+
 ### "Like" Specific Reaction
 
 The "like" reaction has some additional functionality. A "like" can be "unliked". This shouldn't be confused with a "dislike" as a "dislike" counts as an engagement, whereas an "unlike" is deleting the engagement.

--- a/src/Concerns/HasEngagements.php
+++ b/src/Concerns/HasEngagements.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Cjmellor\Engageify\Concerns;
 
 use Cjmellor\Engageify\Contracts\EngagementType;
+use Cjmellor\Engageify\Contracts\Exclusive;
 use Cjmellor\Engageify\Contracts\HasWeight;
 use Cjmellor\Engageify\Enums\EngagementTypes;
 use Cjmellor\Engageify\Events\Disengaged;
@@ -16,6 +17,7 @@ use Cjmellor\Engageify\Support\TypeResolver;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 
 trait HasEngagements
 {
@@ -83,6 +85,10 @@ trait HasEngagements
     {
         $type = TypeResolver::ensure(type: $type);
 
+        if ($type instanceof Exclusive) {
+            return $this->engageExclusive(type: $type, value: $value);
+        }
+
         throw_if(
             config(key: 'engageify.allow_multiple_engagements') === false && $this->hasEngagedWithType(type: $type),
             UserCannotEngageException::class,
@@ -137,6 +143,84 @@ trait HasEngagements
         return $this->engagements()
             ->whereType($type)
             ->count();
+    }
+
+    public function netScore(string $group): float
+    {
+        return (float) $this->engagements()
+            ->whereIn('type', $this->exclusiveGroupValues(group: $group))
+            ->sum(column: 'value');
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    public function breakdown(string $group): array
+    {
+        $rows = $this->engagements()
+            ->whereIn('type', $this->exclusiveGroupValues(group: $group))
+            ->toBase()
+            ->selectRaw('type, count(*) as aggregate')
+            ->groupBy('type')
+            ->get();
+
+        $breakdown = [];
+
+        foreach ($rows as $row) {
+            $breakdown[(string) $row->type] = (int) $row->aggregate;
+        }
+
+        return $breakdown;
+    }
+
+    protected function engageExclusive(EngagementType&Exclusive $type, int|float|null $value): Engagement
+    {
+        return DB::transaction(fn (): Engagement => $this->flipExclusive(type: $type, value: $value));
+    }
+
+    protected function flipExclusive(EngagementType&Exclusive $type, int|float|null $value): Engagement
+    {
+        $existing = $this->engagements()
+            ->whereUserId(auth()->id())
+            ->whereIn('type', $this->exclusiveGroupValues(group: $type->group()))
+            ->lockForUpdate()
+            ->get();
+
+        $active = $existing->first(fn (Engagement $engagement): bool => $engagement->type === $type);
+
+        $existing->each(function (Engagement $engagement): void {
+            $engagement->delete();
+
+            event(new Disengaged(actor: auth()->user(), engageable: $this, type: $engagement->type));
+        });
+
+        if ($active instanceof Engagement) {
+            return $active;
+        }
+
+        $engagement = $this->engagements()->create([
+            'user_id' => auth()->id(),
+            'type' => $type,
+            'value' => $this->resolveEngagementValue(type: $type, value: $value),
+        ]);
+
+        event(new Engaged(actor: auth()->user(), engageable: $this, type: $type, engagement: $engagement));
+
+        return $engagement;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    protected function exclusiveGroupValues(string $group): array
+    {
+        $enum = TypeResolver::enum();
+
+        return collect($enum::cases())
+            ->filter(fn (EngagementType $case): bool => $case instanceof Exclusive && $case->group() === $group)
+            ->map(fn (EngagementType $case): string => $case->value)
+            ->values()
+            ->all();
     }
 
     protected function resolveEngagementValue(EngagementType $type, int|float|null $value): int|float|null

--- a/src/Contracts/Exclusive.php
+++ b/src/Contracts/Exclusive.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cjmellor\Engageify\Contracts;
+
+interface Exclusive
+{
+    public function group(): string;
+}

--- a/src/Models/Engagement.php
+++ b/src/Models/Engagement.php
@@ -4,11 +4,16 @@ declare(strict_types=1);
 
 namespace Cjmellor\Engageify\Models;
 
+use Cjmellor\Engageify\Contracts\EngagementType;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 
+/**
+ * @property EngagementType $type
+ * @property string|null $value
+ */
 class Engagement extends Model
 {
     use HasFactory;

--- a/tests/Concerns/ExclusiveGroupTest.php
+++ b/tests/Concerns/ExclusiveGroupTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+use Cjmellor\Engageify\Events\Disengaged;
+use Cjmellor\Engageify\Events\Engaged;
+use Cjmellor\Engageify\Tests\Fixtures\Enums\Ballot;
+use Cjmellor\Engageify\Tests\Fixtures\Enums\Mood;
+use Cjmellor\Engageify\Tests\Fixtures\User;
+use Illuminate\Support\Facades\Event;
+
+beforeEach(function (): void {
+    config(['engageify.types' => Ballot::class]);
+
+    $this->actingAs($this->user);
+});
+
+test('switching within a group deletes the old member and inserts the new, never two rows', function (): void {
+    $this->user->engage(Ballot::Down);
+    $this->user->engage(Ballot::Up);
+
+    expect($this->user->engagements()->count())->toBe(1)
+        ->and($this->user->engagements()->first()->type)->toBe(Ballot::Up);
+});
+
+test('re-recording the active member toggles it off', function (): void {
+    $this->user->engage(Ballot::Up);
+    $this->user->engage(Ballot::Up);
+
+    expect($this->user->engagements()->count())->toBe(0);
+});
+
+test('switching fires Disengaged for the cleared member and Engaged for the new', function (): void {
+    Event::fake();
+
+    $this->user->engage(Ballot::Down);
+    $this->user->engage(Ballot::Up);
+
+    Event::assertDispatched(Disengaged::class, fn (Disengaged $event): bool => $event->type === Ballot::Down);
+    Event::assertDispatched(Engaged::class, fn (Engaged $event): bool => $event->type === Ballot::Up);
+});
+
+test('netScore sums the weights across a group', function (): void {
+    $target = $this->user;
+    $voterA = User::factory()->createOne();
+    $voterB = User::factory()->createOne();
+
+    $this->actingAs($voterA);
+    $target->engage(Ballot::Up);
+
+    $this->actingAs($voterB);
+    $target->engage(Ballot::Up);
+
+    $this->actingAs($target);
+    $target->engage(Ballot::Down);
+
+    expect($target->netScore('ballot'))->toBe(1.0);
+});
+
+test('breakdown returns per-member counts across a group', function (): void {
+    $target = $this->user;
+    $voterA = User::factory()->createOne();
+
+    $this->actingAs($voterA);
+    $target->engage(Ballot::Up);
+
+    $this->actingAs($target);
+    $target->engage(Ballot::Down);
+
+    expect($target->breakdown('ballot'))
+        ->toHaveKey('ballot_up', 1)
+        ->toHaveKey('ballot_down', 1);
+});
+
+test('a vote switch is atomic — a failure during the flip rolls back, leaving the original vote intact', function (): void {
+    $this->user->engage(Ballot::Down);
+
+    Event::listen(Engaged::class, function (): void {
+        throw new RuntimeException('listener boom');
+    });
+
+    expect(fn (): mixed => $this->user->engage(Ballot::Up))
+        ->toThrow(exception: RuntimeException::class);
+
+    expect($this->user->engagements()->count())->toBe(1)
+        ->and($this->user->engagements()->first()->type)->toBe(Ballot::Down);
+});
+
+test('a non-weighted reaction group switches between members and carries no value', function (): void {
+    config(['engageify.types' => Mood::class]);
+
+    $target = $this->user;
+    $voterA = User::factory()->createOne();
+
+    $this->actingAs($voterA);
+    $target->engage(Mood::Happy);
+
+    $this->actingAs($target);
+    $target->engage(Mood::Sad);
+    $target->engage(Mood::Angry);
+
+    expect($target->engagements()->count())->toBe(2)
+        ->and($target->breakdown('mood'))->toHaveKey('happy', 1)
+        ->and($target->breakdown('mood'))->toHaveKey('angry', 1)
+        ->and($target->netScore('mood'))->toBe(0.0)
+        ->and($target->engagements()->whereType(Mood::Angry)->first()->value)->toBeNull();
+});

--- a/tests/Fixtures/Enums/Ballot.php
+++ b/tests/Fixtures/Enums/Ballot.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cjmellor\Engageify\Tests\Fixtures\Enums;
+
+use Cjmellor\Engageify\Contracts\EngagementType;
+use Cjmellor\Engageify\Contracts\Exclusive;
+use Cjmellor\Engageify\Contracts\HasWeight;
+
+enum Ballot: string implements EngagementType, Exclusive, HasWeight
+{
+    case Up = 'ballot_up';
+    case Down = 'ballot_down';
+
+    public function weight(): int
+    {
+        return match ($this) {
+            self::Up => 1,
+            self::Down => -1,
+        };
+    }
+
+    public function group(): string
+    {
+        return 'ballot';
+    }
+}

--- a/tests/Fixtures/Enums/Mood.php
+++ b/tests/Fixtures/Enums/Mood.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cjmellor\Engageify\Tests\Fixtures\Enums;
+
+use Cjmellor\Engageify\Contracts\EngagementType;
+use Cjmellor\Engageify\Contracts\Exclusive;
+
+enum Mood: string implements EngagementType, Exclusive
+{
+    case Happy = 'happy';
+    case Sad = 'sad';
+    case Angry = 'angry';
+
+    public function group(): string
+    {
+        return 'mood';
+    }
+}


### PR DESCRIPTION
Implements #30.

## What

- `Exclusive` capability interface (`group(): string`).
- Recording an Exclusive Verb **atomically** (one DB transaction) clears any existing engagement by the same actor+engageable sharing the group key, then records the new one. Re-recording the active member **toggles it off**; switching can never leave two rows.
- Switching fires `Disengaged` (cleared) + `Engaged` (new).
- `netScore($group)` = summed weights across the Group; `breakdown($group)` = per-member counts.

## Acceptance criteria

- [x] Switching within a group deletes old + inserts new atomically; never two rows for one actor+target+group
- [x] Re-recording the active member removes it (toggle-off); a different member switches
- [x] Switching fires `Disengaged` (cleared) + `Engaged` (new)
- [x] `netScore(group)` returns summed weights; `breakdown(group)` returns per-member counts
- [x] 100% coverage including an atomicity test (forced mid-flip failure rolls back, leaving the original vote intact)

Full suite green: 45 tests / 81 assertions, 100% code + type coverage, larastan level 5 clean, Pint + Rector clean.

See ADR-0003 (net-score across a group is owned here, not the value pitch) and PRD §Exclusive behaviour.