### PR TITLE
[2.x] Ratings: Rateable scale + upsert semantics + distribution + Bayesian average

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,52 @@ $post->netScore('vote');   // e.g. 42
 $post->breakdown('vote');  // ['up' => 50, 'down' => 8]
 ```
 
+### Ratings
+
+For star-style or scored ratings, implement `Cjmellor\Engageify\Contracts\Rateable` with a `min()`, `max()` and `step()` (return `null` for a continuous scale). A `Rateable` Verb takes a **caller-supplied value validated against its scale**:
+
+```php
+use Cjmellor\Engageify\Contracts\EngagementType;
+use Cjmellor\Engageify\Contracts\Rateable;
+
+enum Rating: string implements EngagementType, Rateable
+{
+    case Stars = 'stars';
+
+    public function min(): float
+    {
+        return 1.0;
+    }
+
+    public function max(): float
+    {
+        return 5.0;
+    }
+
+    public function step(): ?float
+    {
+        return 1.0;
+    }
+}
+```
+
+```php
+$film->engage(Rating::Stars, 4);   // stored, validated against 1–5 step 1
+$film->engage(Rating::Stars, 6);   // throws InvalidRatingException (out of range)
+$film->engage(Rating::Stars, 2.5); // throws InvalidRatingException (off step)
+```
+
+Ratings are **scalar with upsert semantics**: at most one rating per user per target. Re-rating updates the existing row (and ignores `allow_multiple_engagements` entirely — re-rating is governed by the Verb, not config). Read them back with:
+
+```php
+$film->averageRating(Rating::Stars);     // mean rating
+$film->ratingCount(Rating::Stars);       // number of ratings
+$film->ratingDistribution(Rating::Stars); // ['5.00' => 12, '4.00' => 3, ...]
+$film->bayesianAverage(Rating::Stars);    // mean pulled toward the global average for low-count items
+```
+
+`bayesianAverage()` seeds each target with `m` "average" votes (the `engageify.bayesian_minimum` config, overridable per call) so a single 5-star rating doesn't outrank a film with hundreds of high scores.
+
 ### "Like" Specific Reaction
 
 The "like" reaction has some additional functionality. A "like" can be "unliked". This shouldn't be confused with a "dislike" as a "dislike" counts as an engagement, whereas an "unlike" is deleting the engagement.

--- a/config/engageify.php
+++ b/config/engageify.php
@@ -50,4 +50,16 @@ return [
     */
     'allow_caching' => env(key: 'ENGAGEIFY_ALLOW_CACHING', default: false),
     'cache_duration' => env(key: 'ENGAGEIFY_CACHE_DURATION', default: 3600),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Bayesian Minimum
+    |--------------------------------------------------------------------------
+    |
+    | The prior weight (m) used by bayesianAverage(): the number of "average"
+    | votes an Engageable is seeded with before its own ratings outweigh the
+    | global mean. Higher values pull low-count items harder toward the mean.
+    |
+    */
+    'bayesian_minimum' => env(key: 'ENGAGEIFY_BAYESIAN_MINIMUM', default: 5),
 ];

--- a/src/Concerns/HasEngagements.php
+++ b/src/Concerns/HasEngagements.php
@@ -7,12 +7,15 @@ namespace Cjmellor\Engageify\Concerns;
 use Cjmellor\Engageify\Contracts\EngagementType;
 use Cjmellor\Engageify\Contracts\Exclusive;
 use Cjmellor\Engageify\Contracts\HasWeight;
+use Cjmellor\Engageify\Contracts\Rateable;
 use Cjmellor\Engageify\Enums\EngagementTypes;
 use Cjmellor\Engageify\Events\Disengaged;
 use Cjmellor\Engageify\Events\Engaged;
 use Cjmellor\Engageify\Exceptions\EngagementValueException;
+use Cjmellor\Engageify\Exceptions\InvalidRatingException;
 use Cjmellor\Engageify\Exceptions\UserCannotEngageException;
 use Cjmellor\Engageify\Models\Engagement;
+use Cjmellor\Engageify\Support\RatingScale;
 use Cjmellor\Engageify\Support\TypeResolver;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
@@ -87,6 +90,10 @@ trait HasEngagements
 
         if ($type instanceof Exclusive) {
             return $this->engageExclusive(type: $type, value: $value);
+        }
+
+        if ($type instanceof Rateable) {
+            return $this->rate(type: $type, value: $value);
         }
 
         throw_if(
@@ -173,6 +180,44 @@ trait HasEngagements
         return $breakdown;
     }
 
+    public function averageRating(EngagementType $type): float
+    {
+        return $this->averageOf(type: $type);
+    }
+
+    public function ratingCount(EngagementType $type): int
+    {
+        return $this->engagementCount(type: $type);
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    public function ratingDistribution(EngagementType $type): array
+    {
+        return $this->engagements()
+            ->whereType($type)
+            ->get()
+            ->groupBy(fn (Engagement $engagement): string => (string) $engagement->value)
+            ->map(fn (Collection $group): int => $group->count())
+            ->all();
+    }
+
+    public function bayesianAverage(EngagementType $type, ?int $m = null): float
+    {
+        $m ??= (int) config(key: 'engageify.bayesian_minimum');
+
+        $count = $this->engagements()->whereType($type)->count();
+        $sum = (float) $this->engagements()->whereType($type)->sum(column: 'value');
+        $globalMean = (float) Engagement::query()->where('type', $type->value)->avg(column: 'value');
+
+        $denominator = $m + $count;
+
+        return $denominator === 0
+            ? 0.0
+            : ($m * $globalMean + $sum) / $denominator;
+    }
+
     protected function engageExclusive(EngagementType&Exclusive $type, int|float|null $value): Engagement
     {
         return DB::transaction(fn (): Engagement => $this->flipExclusive(type: $type, value: $value));
@@ -223,6 +268,20 @@ trait HasEngagements
             ->all();
     }
 
+    protected function rate(EngagementType&Rateable $type, int|float|null $value): Engagement
+    {
+        throw_if($value === null, InvalidRatingException::valueRequired(type: $type));
+
+        $engagement = $this->engagements()->updateOrCreate(
+            attributes: ['user_id' => auth()->id(), 'type' => $type],
+            values: ['value' => RatingScale::validate(type: $type, value: $value)],
+        );
+
+        event(new Engaged(actor: auth()->user(), engageable: $this, type: $type, engagement: $engagement));
+
+        return $engagement;
+    }
+
     protected function resolveEngagementValue(EngagementType $type, int|float|null $value): int|float|null
     {
         throw_unless($value === null, EngagementValueException::notAccepted(type: $type));
@@ -232,7 +291,7 @@ trait HasEngagements
 
     protected function engagementCarriesValue(EngagementType $type): bool
     {
-        return $type instanceof HasWeight;
+        return $type instanceof HasWeight || $type instanceof Rateable;
     }
 
     protected function hasEngagedWithType(EngagementType $type): bool

--- a/src/Contracts/Rateable.php
+++ b/src/Contracts/Rateable.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cjmellor\Engageify\Contracts;
+
+interface Rateable
+{
+    public function min(): float;
+
+    public function max(): float;
+
+    public function step(): ?float;
+}

--- a/src/Exceptions/InvalidRatingException.php
+++ b/src/Exceptions/InvalidRatingException.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cjmellor\Engageify\Exceptions;
+
+use Cjmellor\Engageify\Contracts\Rateable;
+use Exception;
+
+class InvalidRatingException extends Exception
+{
+    public static function outOfRange(Rateable $type, int|float $value): self
+    {
+        return new self(message: "The rating [{$value}] is outside the allowed range [{$type->min()}, {$type->max()}].");
+    }
+
+    public static function offStep(Rateable $type, int|float $value): self
+    {
+        return new self(message: "The rating [{$value}] is not a multiple of the allowed step [{$type->step()}].");
+    }
+
+    public static function valueRequired(Rateable $type): self
+    {
+        return new self(message: 'A '.$type::class.' rating requires a value.');
+    }
+}

--- a/src/Support/RatingScale.php
+++ b/src/Support/RatingScale.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cjmellor\Engageify\Support;
+
+use Cjmellor\Engageify\Contracts\Rateable;
+use Cjmellor\Engageify\Exceptions\InvalidRatingException;
+
+class RatingScale
+{
+    public static function validate(Rateable $type, int|float $value): float
+    {
+        throw_if(
+            $value < $type->min() || $value > $type->max(),
+            InvalidRatingException::outOfRange(type: $type, value: $value),
+        );
+
+        $step = $type->step();
+
+        if ($step !== null) {
+            $offset = ($value - $type->min()) / $step;
+
+            throw_if(
+                abs($offset - round($offset)) > 1e-9,
+                InvalidRatingException::offStep(type: $type, value: $value),
+            );
+        }
+
+        return (float) $value;
+    }
+}

--- a/tests/Concerns/EngagementRatingTest.php
+++ b/tests/Concerns/EngagementRatingTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+use Cjmellor\Engageify\Exceptions\InvalidRatingException;
+use Cjmellor\Engageify\Tests\Fixtures\Enums\Rating;
+use Cjmellor\Engageify\Tests\Fixtures\User;
+
+beforeEach(function (): void {
+    config(['engageify.types' => Rating::class]);
+
+    $this->actingAs($this->user);
+});
+
+test('a Rateable Verb stores a caller-supplied value validated against its scale', function (): void {
+    $this->user->engage(Rating::Stars, 4);
+
+    expect($this->user->engagements()->count())->toBe(1)
+        ->and((float) $this->user->engagements()->first()->value)->toBe(4.0);
+});
+
+test('a rating outside the scale range throws', function (): void {
+    expect(fn (): mixed => $this->user->engage(Rating::Stars, 6))
+        ->toThrow(exception: InvalidRatingException::class);
+
+    expect(fn (): mixed => $this->user->engage(Rating::Stars, 0))
+        ->toThrow(exception: InvalidRatingException::class);
+});
+
+test('a rating that is off-step throws', function (): void {
+    expect(fn (): mixed => $this->user->engage(Rating::Stars, 2.5))
+        ->toThrow(exception: InvalidRatingException::class);
+});
+
+test('rating without a value throws', function (): void {
+    expect(fn (): mixed => $this->user->engage(Rating::Stars))
+        ->toThrow(exception: InvalidRatingException::class);
+});
+
+test('re-rating updates the existing row and ignores allow_multiple_engagements', function (): void {
+    config(['engageify.allow_multiple_engagements' => false]);
+
+    $this->user->engage(Rating::Stars, 4);
+    $this->user->engage(Rating::Stars, 2);
+
+    expect($this->user->engagements()->count())->toBe(1)
+        ->and((float) $this->user->engagements()->first()->value)->toBe(2.0);
+});
+
+test('fractional ratings are supported on a continuous scale', function (): void {
+    $target = $this->user;
+    $raterA = User::factory()->createOne();
+    $raterB = User::factory()->createOne();
+
+    $this->actingAs($raterA);
+    $target->engage(Rating::Quality, 4.2);
+
+    $this->actingAs($raterB);
+    $target->engage(Rating::Quality, 9.5);
+
+    expect($target->ratingCount(Rating::Quality))->toBe(2)
+        ->and(round($target->averageRating(Rating::Quality), 2))->toBe(6.85);
+});
+
+test('averageRating and ratingCount aggregate ratings across actors', function (): void {
+    $target = $this->user;
+    $raterA = User::factory()->createOne();
+    $raterB = User::factory()->createOne();
+
+    $this->actingAs($raterA);
+    $target->engage(Rating::Stars, 5);
+
+    $this->actingAs($raterB);
+    $target->engage(Rating::Stars, 3);
+
+    expect($target->averageRating(Rating::Stars))->toBe(4.0)
+        ->and($target->ratingCount(Rating::Stars))->toBe(2);
+});
+
+test('ratingDistribution returns a histogram keyed by value', function (): void {
+    $target = $this->user;
+    $raterA = User::factory()->createOne();
+    $raterB = User::factory()->createOne();
+    $raterC = User::factory()->createOne();
+
+    $this->actingAs($raterA);
+    $target->engage(Rating::Stars, 5);
+
+    $this->actingAs($raterB);
+    $target->engage(Rating::Stars, 5);
+
+    $this->actingAs($raterC);
+    $target->engage(Rating::Stars, 3);
+
+    expect($target->ratingDistribution(Rating::Stars))
+        ->toHaveKey('5.00', 2)
+        ->toHaveKey('3.00', 1);
+});
+
+test('bayesianAverage pulls a low-count item toward the global mean, and m is configurable', function (): void {
+    $target = $this->user;
+    $other = User::factory()->createOne();
+    $rater = User::factory()->createOne();
+
+    $this->actingAs($rater);
+    $other->engage(Rating::Stars, 2);
+    $target->engage(Rating::Stars, 5);
+
+    expect(round($target->bayesianAverage(Rating::Stars, 10), 2))->toBe(3.64)
+        ->and(round($target->bayesianAverage(Rating::Stars, 1), 2))->toBe(4.25);
+});
+
+test('bayesianAverage uses the configured minimum when m is omitted', function (): void {
+    config(['engageify.bayesian_minimum' => 1]);
+
+    $target = $this->user;
+    $other = User::factory()->createOne();
+    $rater = User::factory()->createOne();
+
+    $this->actingAs($rater);
+    $other->engage(Rating::Stars, 2);
+    $target->engage(Rating::Stars, 5);
+
+    expect(round($target->bayesianAverage(Rating::Stars), 2))->toBe(4.25);
+});
+
+test('bayesianAverage returns zero when there is no prior and no ratings', function (): void {
+    expect($this->user->bayesianAverage(Rating::Stars, 0))->toBe(0.0);
+});

--- a/tests/Fixtures/Enums/Rating.php
+++ b/tests/Fixtures/Enums/Rating.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cjmellor\Engageify\Tests\Fixtures\Enums;
+
+use Cjmellor\Engageify\Contracts\EngagementType;
+use Cjmellor\Engageify\Contracts\Rateable;
+
+enum Rating: string implements EngagementType, Rateable
+{
+    case Stars = 'stars';
+    case Quality = 'quality';
+
+    public function min(): float
+    {
+        return match ($this) {
+            self::Stars => 1.0,
+            self::Quality => 0.0,
+        };
+    }
+
+    public function max(): float
+    {
+        return match ($this) {
+            self::Stars => 5.0,
+            self::Quality => 10.0,
+        };
+    }
+
+    public function step(): ?float
+    {
+        return match ($this) {
+            self::Stars => 1.0,
+            self::Quality => null,
+        };
+    }
+}


### PR DESCRIPTION
Implements #31.

## What

- `Rateable` capability (`min()`/`max()`/`step()`) and a `RatingScale` validator: a Rateable Verb takes a caller-supplied value validated against its scale (out-of-range or off-step throws `InvalidRatingException`).
- Upsert semantics: one row per (actor, engageable, Verb); re-rating updates `value` + `updated_at`. This **overrides `allow_multiple_engagements`** (per ADR-0004).
- Reads: `averageRating()` (alias over `averageOf`), `ratingCount()`, `ratingDistribution()` (histogram), `bayesianAverage(?int $m)` with the global mean computed live and `m` defaulting to `engageify.bayesian_minimum`.

## Acceptance criteria

- [x] A `Rateable` Verb validates value against min/max/step; out-of-range or off-step throws
- [x] Re-rating updates the existing row (one per actor+target+Verb), ignoring `allow_multiple_engagements`
- [x] `averageRating`/`ratingCount`/`ratingDistribution` return correct aggregates
- [x] `bayesianAverage` pulls low-count items toward the global mean; `m` configurable
- [x] Fractional values (4.2, 9.5) supported; 100% code + type coverage

Full suite green: 56 tests / 101 assertions, 100% code + type coverage, larastan level 5 clean, Pint + Rector clean.

See ADR-0004 (ratings are scalar/upsert and override multiple-engagements).