### PR TITLE
[2.x] Counters: transactional engagement_counters, cache removal, recount, ranking scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,18 +261,23 @@ $post->upvotes();
 $post->downvotes();
 ```
 
-### Caching Engagement Counts
+Counts are read from a denormalised `engagement_counters` table that is kept in step **inside the same database transaction** as every engage/disengage/flip — so they are always fresh and O(1) to read (no cache to invalidate, and no stale-count-after-unlike bug).
 
-A caching feature is available, which is off by default but can be changed in the config file, or by adding it to your `.env` file
+> The counters are maintained automatically. If you ever write engagement rows directly (bypassing the trait), rebuild them with `php artisan engageify:recount`.
 
-```text
-ENGAGEIFY_ALLOW_CACHING=true
-ENGAGEIFY_CACHE_DURATION=3600
+### Ranking
+
+Because counts live in the database, you can sort by them in SQL straight from the Engageable's query builder:
+
+```php
+// Most-liked posts first
+Post::query()->orderByEngagementCount(EngagementTypes::Like)->get();
+
+// Highest net vote score first
+Post::query()->orderByScore('vote')->get();
 ```
 
-When an engagement is retrieved, it is cached, and further requests will retireve the data from the cache.
-
-On each new engagement, the cache will be cleared.
+Both accept a direction (`'desc'` by default).
 
 #### Fetch Users' Who Engaged
 

--- a/config/engageify.php
+++ b/config/engageify.php
@@ -42,17 +42,6 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Allow Caching
-    |--------------------------------------------------------------------------
-    |
-    | The engagement counts can be cached to improve performance.
-    |
-    */
-    'allow_caching' => env(key: 'ENGAGEIFY_ALLOW_CACHING', default: false),
-    'cache_duration' => env(key: 'ENGAGEIFY_CACHE_DURATION', default: 3600),
-
-    /*
-    |--------------------------------------------------------------------------
     | Bayesian Minimum
     |--------------------------------------------------------------------------
     |

--- a/database/migrations/2026_05_31_000001_create_engagement_counters_table.php
+++ b/database/migrations/2026_05_31_000001_create_engagement_counters_table.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('engagement_counters', function (Blueprint $table): void {
+            $table->id();
+            $table->morphs(name: 'engagementable');
+            $table->string(column: 'type');
+            $table->unsignedBigInteger(column: 'count')->default(0);
+            $table->decimal(column: 'sum_value', total: 8, places: 2)->default(0);
+            $table->timestamps();
+
+            $table->unique(columns: ['engagementable_type', 'engagementable_id', 'type']);
+        });
+
+        Schema::table('engagements', function (Blueprint $table): void {
+            $table->index(columns: ['engagementable_type', 'engagementable_id', 'type']);
+        });
+    }
+};

--- a/rector.php
+++ b/rector.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;
+use RectorLaravel\Rector\Class_\DescriptionPropertyToDescriptionAttributeRector;
+use RectorLaravel\Rector\Class_\SignaturePropertyToSignatureAttributeRector;
 use RectorLaravel\Rector\FuncCall\RemoveDumpDataDeadCodeRector;
 use RectorLaravel\Set\LaravelSetList;
 use RectorLaravel\Set\LaravelSetProvider;
@@ -15,7 +17,11 @@ return RectorConfig::configure()
         __DIR__.'/src',
         __DIR__.'/tests',
     ])
-    ->withSkip([AddOverrideAttributeToOverriddenMethodsRector::class])
+    ->withSkip([
+        AddOverrideAttributeToOverriddenMethodsRector::class,
+        SignaturePropertyToSignatureAttributeRector::class,
+        DescriptionPropertyToDescriptionAttributeRector::class,
+    ])
     ->withPreparedSets(
         deadCode: true,
         codeQuality: true,

--- a/src/Commands/RecountCommand.php
+++ b/src/Commands/RecountCommand.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cjmellor\Engageify\Commands;
+
+use Cjmellor\Engageify\Models\EngagementCounter;
+use Illuminate\Console\Command;
+
+#[\Illuminate\Console\Attributes\Description('Rebuild the engagement counters from the source engagement rows.')]
+#[\Illuminate\Console\Attributes\Signature('engageify:recount')]
+class RecountCommand extends Command
+{
+    public function handle(): int
+    {
+        EngagementCounter::rebuild();
+
+        $this->info(string: 'Engagement counters rebuilt.');
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Commands/RecountCommand.php
+++ b/src/Commands/RecountCommand.php
@@ -7,10 +7,12 @@ namespace Cjmellor\Engageify\Commands;
 use Cjmellor\Engageify\Models\EngagementCounter;
 use Illuminate\Console\Command;
 
-#[\Illuminate\Console\Attributes\Description('Rebuild the engagement counters from the source engagement rows.')]
-#[\Illuminate\Console\Attributes\Signature('engageify:recount')]
 class RecountCommand extends Command
 {
+    protected $signature = 'engageify:recount';
+
+    protected $description = 'Rebuild the engagement counters from the source engagement rows.';
+
     public function handle(): int
     {
         EngagementCounter::rebuild();

--- a/src/Concerns/HasEngagements.php
+++ b/src/Concerns/HasEngagements.php
@@ -15,8 +15,10 @@ use Cjmellor\Engageify\Exceptions\EngagementValueException;
 use Cjmellor\Engageify\Exceptions\InvalidRatingException;
 use Cjmellor\Engageify\Exceptions\UserCannotEngageException;
 use Cjmellor\Engageify\Models\Engagement;
+use Cjmellor\Engageify\Models\EngagementCounter;
 use Cjmellor\Engageify\Support\RatingScale;
 use Cjmellor\Engageify\Support\TypeResolver;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Support\Collection;
@@ -30,6 +32,14 @@ trait HasEngagements
     public function engagements(): MorphMany
     {
         return $this->morphMany(related: Engagement::class, name: 'engagementable');
+    }
+
+    /**
+     * @return MorphMany<EngagementCounter, $this>
+     */
+    public function engagementCounters(): MorphMany
+    {
+        return $this->morphMany(related: EngagementCounter::class, name: 'engagementable');
     }
 
     public function like(): Model
@@ -102,19 +112,21 @@ trait HasEngagements
             'This model has already been engaged'
         );
 
-        if (config(key: 'engageify.allow_caching')) {
-            cache()->forget(key: $this->getEngagementCacheKey($type));
-        }
+        $resolved = $this->resolveEngagementValue(type: $type, value: $value);
 
-        $engagement = $this->engagements()->create([
-            'user_id' => auth()->id(),
-            'type' => $type,
-            'value' => $this->resolveEngagementValue(type: $type, value: $value),
-        ]);
+        return DB::transaction(function () use ($type, $resolved): Engagement {
+            $engagement = $this->engagements()->create([
+                'user_id' => auth()->id(),
+                'type' => $type,
+                'value' => $resolved,
+            ]);
 
-        event(new Engaged(actor: auth()->user(), engageable: $this, type: $type, engagement: $engagement));
+            EngagementCounter::record(engageable: $this, type: $type, countDelta: 1, valueDelta: (float) ($resolved ?? 0));
 
-        return $engagement;
+            event(new Engaged(actor: auth()->user(), engageable: $this, type: $type, engagement: $engagement));
+
+            return $engagement;
+        });
     }
 
     public function score(EngagementType $type): float
@@ -123,7 +135,7 @@ trait HasEngagements
 
         throw_unless($this->engagementCarriesValue(type: $type), EngagementValueException::notAvailable(type: $type));
 
-        return (float) $this->engagements()->whereType($type)->sum(column: 'value');
+        return $this->counterSum(type: $type);
     }
 
     public function averageOf(EngagementType $type): float
@@ -132,31 +144,44 @@ trait HasEngagements
 
         throw_unless($this->engagementCarriesValue(type: $type), EngagementValueException::notAvailable(type: $type));
 
-        return (float) $this->engagements()->whereType($type)->avg(column: 'value');
+        $count = $this->counterCount(type: $type);
+
+        return $count === 0 ? 0.0 : $this->counterSum(type: $type) / $count;
     }
 
     public function disengage(EngagementType $type): void
     {
-        $this->engagements()
-            ->whereUserId(auth()->id())
-            ->whereType($type)
-            ->delete();
+        DB::transaction(function () use ($type): void {
+            $engagements = $this->engagements()
+                ->whereUserId(auth()->id())
+                ->whereType($type)
+                ->get();
 
-        event(new Disengaged(actor: auth()->user(), engageable: $this, type: $type));
+            if ($engagements->isNotEmpty()) {
+                $this->engagements()->whereUserId(auth()->id())->whereType($type)->delete();
+
+                EngagementCounter::record(
+                    engageable: $this,
+                    type: $type,
+                    countDelta: -$engagements->count(),
+                    valueDelta: -(float) $engagements->sum(fn (Engagement $engagement): float => (float) $engagement->value),
+                );
+            }
+
+            event(new Disengaged(actor: auth()->user(), engageable: $this, type: $type));
+        });
     }
 
     public function engagementCount(EngagementType $type): int
     {
-        return $this->engagements()
-            ->whereType($type)
-            ->count();
+        return $this->counterCount(type: $type);
     }
 
     public function netScore(string $group): float
     {
-        return (float) $this->engagements()
+        return (float) $this->engagementCounters()
             ->whereIn('type', $this->exclusiveGroupValues(group: $group))
-            ->sum(column: 'value');
+            ->sum(column: 'sum_value');
     }
 
     /**
@@ -164,17 +189,14 @@ trait HasEngagements
      */
     public function breakdown(string $group): array
     {
-        $rows = $this->engagements()
+        $counters = $this->engagementCounters()
             ->whereIn('type', $this->exclusiveGroupValues(group: $group))
-            ->toBase()
-            ->selectRaw('type, count(*) as aggregate')
-            ->groupBy('type')
             ->get();
 
         $breakdown = [];
 
-        foreach ($rows as $row) {
-            $breakdown[(string) $row->type] = (int) $row->aggregate;
+        foreach ($counters as $counter) {
+            $breakdown[$counter->type] = $counter->count;
         }
 
         return $breakdown;
@@ -207,15 +229,65 @@ trait HasEngagements
     {
         $m ??= (int) config(key: 'engageify.bayesian_minimum');
 
-        $count = $this->engagements()->whereType($type)->count();
-        $sum = (float) $this->engagements()->whereType($type)->sum(column: 'value');
-        $globalMean = (float) Engagement::query()->where('type', $type->value)->avg(column: 'value');
+        $count = $this->counterCount(type: $type);
+        $sum = $this->counterSum(type: $type);
+
+        $globalCount = (int) EngagementCounter::query()->where('type', $type->value)->sum(column: 'count');
+        $globalSum = (float) EngagementCounter::query()->where('type', $type->value)->sum(column: 'sum_value');
+        $globalMean = $globalCount === 0 ? 0.0 : $globalSum / $globalCount;
 
         $denominator = $m + $count;
 
         return $denominator === 0
             ? 0.0
             : ($m * $globalMean + $sum) / $denominator;
+    }
+
+    /**
+     * @param  Builder<static>  $query
+     * @return Builder<static>
+     */
+    protected function scopeOrderByEngagementCount(Builder $query, EngagementType $type, string $direction = 'desc'): Builder
+    {
+        $model = $query->getModel();
+
+        return $query
+            ->leftJoinSub(
+                EngagementCounter::query()
+                    ->select(['engagementable_id', 'count'])
+                    ->where('engagementable_type', $model->getMorphClass())
+                    ->where('type', $type->value),
+                'engagement_counts',
+                'engagement_counts.engagementable_id',
+                '=',
+                $model->getQualifiedKeyName(),
+            )
+            ->orderBy('engagement_counts.count', $direction)
+            ->select("{$model->getTable()}.*");
+    }
+
+    /**
+     * @param  Builder<static>  $query
+     * @return Builder<static>
+     */
+    protected function scopeOrderByScore(Builder $query, string $group, string $direction = 'desc'): Builder
+    {
+        $model = $query->getModel();
+
+        return $query
+            ->leftJoinSub(
+                EngagementCounter::query()
+                    ->selectRaw('engagementable_id, sum(sum_value) as group_score')
+                    ->where('engagementable_type', $model->getMorphClass())
+                    ->whereIn('type', $this->exclusiveGroupValues(group: $group))
+                    ->groupBy('engagementable_id'),
+                'engagement_scores',
+                'engagement_scores.engagementable_id',
+                '=',
+                $model->getQualifiedKeyName(),
+            )
+            ->orderBy('engagement_scores.group_score', $direction)
+            ->select("{$model->getTable()}.*");
     }
 
     protected function engageExclusive(EngagementType&Exclusive $type, int|float|null $value): Engagement
@@ -236,6 +308,8 @@ trait HasEngagements
         $existing->each(function (Engagement $engagement): void {
             $engagement->delete();
 
+            EngagementCounter::record(engageable: $this, type: $engagement->type, countDelta: -1, valueDelta: -(float) $engagement->value);
+
             event(new Disengaged(actor: auth()->user(), engageable: $this, type: $engagement->type));
         });
 
@@ -243,11 +317,15 @@ trait HasEngagements
             return $active;
         }
 
+        $resolved = $this->resolveEngagementValue(type: $type, value: $value);
+
         $engagement = $this->engagements()->create([
             'user_id' => auth()->id(),
             'type' => $type,
-            'value' => $this->resolveEngagementValue(type: $type, value: $value),
+            'value' => $resolved,
         ]);
+
+        EngagementCounter::record(engageable: $this, type: $type, countDelta: 1, valueDelta: (float) ($resolved ?? 0));
 
         event(new Engaged(actor: auth()->user(), engageable: $this, type: $type, engagement: $engagement));
 
@@ -272,14 +350,37 @@ trait HasEngagements
     {
         throw_if($value === null, InvalidRatingException::valueRequired(type: $type));
 
-        $engagement = $this->engagements()->updateOrCreate(
-            attributes: ['user_id' => auth()->id(), 'type' => $type],
-            values: ['value' => RatingScale::validate(type: $type, value: $value)],
-        );
+        $validated = RatingScale::validate(type: $type, value: $value);
 
-        event(new Engaged(actor: auth()->user(), engageable: $this, type: $type, engagement: $engagement));
+        return DB::transaction(function () use ($type, $validated): Engagement {
+            $existing = $this->engagements()
+                ->whereUserId(auth()->id())
+                ->whereType($type)
+                ->lockForUpdate()
+                ->first();
 
-        return $engagement;
+            if ($existing instanceof Engagement) {
+                $previous = (float) $existing->value;
+
+                $existing->update(['value' => $validated]);
+
+                EngagementCounter::record(engageable: $this, type: $type, countDelta: 0, valueDelta: $validated - $previous);
+
+                $engagement = $existing;
+            } else {
+                $engagement = $this->engagements()->create([
+                    'user_id' => auth()->id(),
+                    'type' => $type,
+                    'value' => $validated,
+                ]);
+
+                EngagementCounter::record(engageable: $this, type: $type, countDelta: 1, valueDelta: $validated);
+            }
+
+            event(new Engaged(actor: auth()->user(), engageable: $this, type: $type, engagement: $engagement));
+
+            return $engagement;
+        });
     }
 
     protected function resolveEngagementValue(EngagementType $type, int|float|null $value): int|float|null
@@ -302,11 +403,6 @@ trait HasEngagements
             ->exists();
     }
 
-    protected function getEngagementCacheKey(EngagementType $type): string
-    {
-        return "engagements.$type->value.$this->id";
-    }
-
     protected function getEngagementCount(EngagementType $type, bool $showUsers = false): Collection|int
     {
         if ($showUsers) {
@@ -318,14 +414,20 @@ trait HasEngagements
                 ->when(config(key: 'engageify.allow_multiple_engagements'), fn ($users) => $users->unique());
         }
 
-        if (config(key: 'engageify.allow_caching')) {
-            return cache()->remember(
-                key: $this->getEngagementCacheKey($type),
-                ttl: config(key: 'engageify.cache_duration'),
-                callback: fn () => $this->engagementCount(type: $type)
-            );
-        }
+        return $this->counterCount(type: $type);
+    }
 
-        return $this->engagementCount(type: $type);
+    protected function counterCount(EngagementType $type): int
+    {
+        return (int) $this->engagementCounters()
+            ->where('type', $type->value)
+            ->sum(column: 'count');
+    }
+
+    protected function counterSum(EngagementType $type): float
+    {
+        return (float) $this->engagementCounters()
+            ->where('type', $type->value)
+            ->sum(column: 'sum_value');
     }
 }

--- a/src/EngageifyServiceProvider.php
+++ b/src/EngageifyServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Cjmellor\Engageify;
 
+use Cjmellor\Engageify\Commands\RecountCommand;
 use Illuminate\Support\ServiceProvider;
 
 class EngageifyServiceProvider extends ServiceProvider
@@ -18,6 +19,12 @@ class EngageifyServiceProvider extends ServiceProvider
 
     public function boot(): void
     {
+        if ($this->app->runningInConsole()) {
+            $this->commands(commands: [
+                RecountCommand::class,
+            ]);
+        }
+
         $this->publishes([
             __DIR__.'/../config/engageify.php' => config_path(path: 'engageify.php'),
         ], groups: 'engageify-config');

--- a/src/Models/EngagementCounter.php
+++ b/src/Models/EngagementCounter.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cjmellor\Engageify\Models;
+
+use Cjmellor\Engageify\Contracts\EngagementType;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+/**
+ * @property string $type
+ * @property int $count
+ * @property string $sum_value
+ */
+class EngagementCounter extends Model
+{
+    protected $guarded = [];
+
+    public static function record(Model $engageable, EngagementType $type, int $countDelta, int|float $valueDelta): void
+    {
+        $counter = static::query()->firstOrCreate([
+            'engagementable_type' => $engageable->getMorphClass(),
+            'engagementable_id' => $engageable->getKey(),
+            'type' => $type->value,
+        ]);
+
+        $counter->increment(column: 'count', amount: $countDelta);
+        $counter->increment(column: 'sum_value', amount: $valueDelta);
+    }
+
+    public static function rebuild(): void
+    {
+        static::query()->delete();
+
+        Engagement::query()
+            ->toBase()
+            ->selectRaw('engagementable_type, engagementable_id, type, count(*) as aggregate_count, coalesce(sum(value), 0) as aggregate_sum')
+            ->groupBy('engagementable_type', 'engagementable_id', 'type')
+            ->get()
+            ->each(function (object $row): void {
+                static::query()->create([
+                    'engagementable_type' => $row->engagementable_type,
+                    'engagementable_id' => $row->engagementable_id,
+                    'type' => $row->type,
+                    'count' => (int) $row->aggregate_count,
+                    'sum_value' => (float) $row->aggregate_sum,
+                ]);
+            });
+    }
+
+    public function engagementable(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'sum_value' => 'decimal:2',
+        ];
+    }
+}

--- a/tests/Concerns/EngagementCounterTest.php
+++ b/tests/Concerns/EngagementCounterTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+use Cjmellor\Engageify\Enums\EngagementTypes;
+use Cjmellor\Engageify\Events\Disengaged;
+use Cjmellor\Engageify\Models\EngagementCounter;
+use Cjmellor\Engageify\Tests\Fixtures\Enums\Ballot;
+use Cjmellor\Engageify\Tests\Fixtures\Enums\Rating;
+use Cjmellor\Engageify\Tests\Fixtures\Enums\Vote;
+use Illuminate\Support\Facades\Event;
+
+beforeEach(function (): void {
+    $this->actingAs($this->user);
+});
+
+test('engaging increments the counter and disengaging decrements it — no stale count after unlike', function (): void {
+    $this->user->like();
+
+    expect($this->user->likes())->toBe(1)
+        ->and($this->user->engagementCount(EngagementTypes::Like))->toBe(1);
+
+    $this->user->unlike();
+
+    expect($this->user->likes())->toBe(0);
+
+    $this->assertDatabaseHas(EngagementCounter::class, [
+        'type' => 'like',
+        'count' => 0,
+    ]);
+});
+
+test('a counter belongs to its engageable', function (): void {
+    $this->user->like();
+
+    $counter = EngagementCounter::query()->firstOrFail();
+
+    expect($counter->engagementable->is($this->user))->toBeTrue();
+});
+
+test('a weighted Verb keeps sum_value in step and score reads it', function (): void {
+    config(['engageify.types' => Vote::class, 'engageify.allow_multiple_engagements' => true]);
+
+    $this->user->engage(Vote::Up);
+    $this->user->engage(Vote::Up);
+
+    expect($this->user->score(Vote::Up))->toBe(2.0)
+        ->and($this->user->engagementCount(Vote::Up))->toBe(2);
+});
+
+test('a flip keeps the counter in step for both members', function (): void {
+    config(['engageify.types' => Ballot::class]);
+
+    $this->user->engage(Ballot::Down);
+    $this->user->engage(Ballot::Up);
+
+    expect($this->user->engagementCount(Ballot::Down))->toBe(0)
+        ->and($this->user->engagementCount(Ballot::Up))->toBe(1)
+        ->and($this->user->netScore('ballot'))->toBe(1.0);
+});
+
+test('re-rating updates sum_value without changing the count', function (): void {
+    config(['engageify.types' => Rating::class]);
+
+    $this->user->engage(Rating::Stars, 4);
+
+    expect($this->user->score(Rating::Stars))->toBe(4.0)
+        ->and($this->user->ratingCount(Rating::Stars))->toBe(1);
+
+    $this->user->engage(Rating::Stars, 2);
+
+    expect($this->user->score(Rating::Stars))->toBe(2.0)
+        ->and($this->user->ratingCount(Rating::Stars))->toBe(1);
+});
+
+test('reads return zero for a Verb with no engagements', function (): void {
+    config(['engageify.types' => Vote::class]);
+
+    expect($this->user->engagementCount(Vote::Up))->toBe(0)
+        ->and($this->user->score(Vote::Up))->toBe(0.0)
+        ->and($this->user->averageOf(Vote::Up))->toBe(0.0);
+});
+
+test('disengaging when nothing is engaged fires Disengaged and leaves the counter untouched', function (): void {
+    Event::fake();
+
+    $this->user->unlike();
+
+    Event::assertDispatched(Disengaged::class);
+
+    expect($this->user->likes())->toBe(0);
+
+    $this->assertDatabaseCount(EngagementCounter::class, 0);
+});

--- a/tests/Concerns/HasEngagementsTest.php
+++ b/tests/Concerns/HasEngagementsTest.php
@@ -145,34 +145,6 @@ test(description: 'retrieve unique list of Users\' who engaged with a Model', cl
     EngagementTypes::Downvote->value,
 ]);
 
-test(description: 'engagement counts are cached when caching is enabled', closure: function (): void {
-    config(['engageify.allow_caching' => true]);
-
-    $this->actingAs($this->user);
-
-    $this->user->like();
-
-    $cacheKey = "engagements.like.{$this->user->id}";
-
-    expect(cache()->has(key: $cacheKey))->toBeFalse();
-
-    expect($this->user->likes())->toBe(expected: 1)
-        ->and(cache()->has(key: $cacheKey))->toBeTrue();
-});
-
-test(description: 'the cached count is cleared when a new engagement is made', closure: function (): void {
-    config(['engageify.allow_caching' => true]);
-    config(['engageify.allow_multiple_engagements' => true]);
-
-    $this->actingAs($this->user);
-
-    $this->user->like();
-    expect($this->user->likes())->toBe(expected: 1);
-
-    $this->user->like();
-    expect($this->user->likes())->toBe(expected: 2);
-});
-
 test(description: 'toggleLike likes a Model that has not been liked yet', closure: function (): void {
     $this->actingAs($this->user);
 

--- a/tests/Concerns/RankingScopeTest.php
+++ b/tests/Concerns/RankingScopeTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+use Cjmellor\Engageify\Enums\EngagementTypes;
+use Cjmellor\Engageify\Tests\Fixtures\Enums\Ballot;
+use Cjmellor\Engageify\Tests\Fixtures\User;
+
+test('orderByEngagementCount sorts engageables by their counter in SQL', function (): void {
+    config(['engageify.allow_multiple_engagements' => true]);
+
+    $popular = User::factory()->createOne();
+    $quiet = User::factory()->createOne();
+
+    $this->actingAs($this->user);
+
+    foreach (range(1, 3) as $ignored) {
+        $popular->like();
+    }
+
+    $quiet->like();
+
+    $ordered = User::query()->orderByEngagementCount(EngagementTypes::Like)->pluck('id');
+
+    expect($ordered->take(2)->all())->toBe([$popular->id, $quiet->id]);
+});
+
+test('orderByScore sorts engageables by their net group score in SQL', function (): void {
+    config(['engageify.types' => Ballot::class]);
+
+    $winner = User::factory()->createOne();
+    $loser = User::factory()->createOne();
+    $voterA = User::factory()->createOne();
+    $voterB = User::factory()->createOne();
+
+    $this->actingAs($voterA);
+    $winner->engage(Ballot::Up);
+
+    $this->actingAs($voterB);
+    $winner->engage(Ballot::Up);
+
+    $this->actingAs($voterA);
+    $loser->engage(Ballot::Down);
+
+    $ordered = User::query()->orderByScore('ballot')->pluck('id');
+
+    expect($ordered->take(2)->all())->toBe([$winner->id, $loser->id]);
+});

--- a/tests/Feature/RecountCommandTest.php
+++ b/tests/Feature/RecountCommandTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+use Cjmellor\Engageify\Models\EngagementCounter;
+use Cjmellor\Engageify\Tests\Fixtures\Enums\Vote;
+
+test('engageify:recount rebuilds the counters from the source rows', function (): void {
+    config(['engageify.types' => Vote::class, 'engageify.allow_multiple_engagements' => true]);
+
+    $this->actingAs($this->user);
+
+    $this->user->engage(Vote::Up);
+    $this->user->engage(Vote::Up);
+
+    EngagementCounter::query()->update(['count' => 99, 'sum_value' => 99]);
+
+    $this->artisan('engageify:recount')->assertSuccessful();
+
+    expect($this->user->engagementCount(Vote::Up))->toBe(2)
+        ->and($this->user->score(Vote::Up))->toBe(2.0);
+});


### PR DESCRIPTION
Implements #32.

## What

- Polymorphic `engagement_counters` table (`count` + `sum_value`, unique on engageable+type) updated **inline in the same transaction** as every engage/disengage/flip/rate — never event-driven, so it can't drift.
- **Cache layer removed entirely** (`allow_caching`/`cache_duration` and the `cache()` branches), fixing the v1 stale-count-after-unlike bug. Reads now hit the counter row (O(1)).
- `engageify:recount` artisan command rebuilds counters from source rows.
- Composite `(engagementable_type, engagementable_id, type)` index on `engagements`.
- `orderByEngagementCount($type)` and `orderByScore($group)` SQL ranking scopes.

## Acceptance criteria

- [x] Counter row stays exactly in step across engage/disengage/flip; no drift, no stale counts after unlike
- [x] `allow_caching`/`cache_duration` removed; reads hit the counter row
- [x] `engageify:recount` rebuilds counters to match source rows
- [x] `orderByEngagementCount`/`orderByScore` sort in SQL via the counter
- [x] 100% code + type coverage

Full suite green: 64 tests / 122 assertions, 100% code + type coverage, larastan level 5 clean, Pint + Rector clean.

See ADR-0005 (counts materialised in a counter table, replacing the cache).