### PR TITLE
[2.x] Actor side: EngagesWith trait, hasEngaged/ratingFor, N+1-free withUserEngagement

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,38 @@ Post::query()->orderByScore('vote')->get();
 
 Both accept a direction (`'desc'` by default).
 
+### Actor-Side Queries
+
+So far the API has been *engageable*-side ("how many likes does this post have?"). To answer *actor*-side questions ("what has this user engaged with?"), add the `EngagesWith` trait to your actor (usually the `User`) model:
+
+```php
+use Cjmellor\Engageify\Concerns\EngagesWith;
+
+class User extends Authenticatable
+{
+    use EngagesWith;
+}
+```
+
+```php
+$user->hasEngaged($post, EngagementTypes::Like);     // bool
+$user->engagementValueFor($post, Vote::Up);          // the stored value, or null
+$user->ratingFor($film, Rating::Stars);              // alias for engagementValueFor
+$user->engagements;                                  // every engagement this user authored
+```
+
+> If a model is **both** an actor and an engageable, both traits expose an `engagements()` relation — resolve the clash with PHP's trait syntax (`HasEngagements::engagements insteadof EngagesWith;` and alias the other).
+
+#### Feed state without N+1
+
+`withUserEngagement($type, ?$user = null)` attaches each engageable's state for a given user (defaulting to the auth user) as a typed `is_engaged` boolean — plus an `engagement_value` for `Rateable` Verbs — resolved for the whole result set in **one** query:
+
+```php
+$feed = Post::query()->withUserEngagement(EngagementTypes::Like)->get();
+
+$feed->first()->is_engaged; // true/false — no extra query per row
+```
+
 #### Fetch Users' Who Engaged
 
 Instead of just fetching the amount of engagements, you can fetch the Users who engaged.

--- a/src/Concerns/EngagesWith.php
+++ b/src/Concerns/EngagesWith.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cjmellor\Engageify\Concerns;
+
+use Cjmellor\Engageify\Contracts\EngagementType;
+use Cjmellor\Engageify\Models\Engagement;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+trait EngagesWith
+{
+    /**
+     * @return HasMany<Engagement, $this>
+     */
+    public function engagements(): HasMany
+    {
+        return $this->hasMany(related: Engagement::class, foreignKey: 'user_id');
+    }
+
+    public function hasEngaged(Model $target, EngagementType $type): bool
+    {
+        return $this->engagementQueryFor(target: $target, type: $type)->exists();
+    }
+
+    public function engagementValueFor(Model $target, EngagementType $type): ?float
+    {
+        $value = $this->engagementQueryFor(target: $target, type: $type)->value('value');
+
+        return $value === null ? null : (float) $value;
+    }
+
+    public function ratingFor(Model $target, EngagementType $type): ?float
+    {
+        return $this->engagementValueFor(target: $target, type: $type);
+    }
+
+    /**
+     * @return Builder<Engagement>
+     */
+    protected function engagementQueryFor(Model $target, EngagementType $type): Builder
+    {
+        return Engagement::query()
+            ->where('user_id', $this->getKey())
+            ->where('engagementable_type', $target->getMorphClass())
+            ->where('engagementable_id', $target->getKey())
+            ->where('type', $type->value);
+    }
+}

--- a/src/Concerns/HasEngagements.php
+++ b/src/Concerns/HasEngagements.php
@@ -290,6 +290,42 @@ trait HasEngagements
             ->select("{$model->getTable()}.*");
     }
 
+    /**
+     * @param  Builder<static>  $query
+     * @return Builder<static>
+     */
+    protected function scopeWithUserEngagement(Builder $query, EngagementType $type, ?Model $user = null): Builder
+    {
+        $userKey = $user?->getKey() ?? auth()->id();
+
+        $model = $query->getModel();
+
+        $query
+            ->addSelect("{$model->getTable()}.*")
+            ->addSelect(['is_engaged' => $this->userEngagementSubquery(model: $model, type: $type, userKey: $userKey)->selectRaw('count(*)')])
+            ->withCasts(['is_engaged' => 'boolean']);
+
+        if ($type instanceof Rateable) {
+            $query
+                ->addSelect(['engagement_value' => $this->userEngagementSubquery(model: $model, type: $type, userKey: $userKey)->select('value')->limit(1)])
+                ->withCasts(['engagement_value' => 'decimal:2']);
+        }
+
+        return $query;
+    }
+
+    /**
+     * @return Builder<Engagement>
+     */
+    protected function userEngagementSubquery(Model $model, EngagementType $type, mixed $userKey): Builder
+    {
+        return Engagement::query()
+            ->whereColumn('engagementable_id', $model->getQualifiedKeyName())
+            ->where('engagementable_type', $model->getMorphClass())
+            ->where('type', $type->value)
+            ->where('user_id', $userKey);
+    }
+
     protected function engageExclusive(EngagementType&Exclusive $type, int|float|null $value): Engagement
     {
         return DB::transaction(fn (): Engagement => $this->flipExclusive(type: $type, value: $value));

--- a/tests/Concerns/EngagesWithTest.php
+++ b/tests/Concerns/EngagesWithTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+use Cjmellor\Engageify\Enums\EngagementTypes;
+use Cjmellor\Engageify\Tests\Fixtures\Enums\Rating;
+use Cjmellor\Engageify\Tests\Fixtures\Enums\Vote;
+use Cjmellor\Engageify\Tests\Fixtures\User;
+use Illuminate\Support\Facades\DB;
+
+beforeEach(function (): void {
+    $this->actor = $this->user;
+    $this->target = User::factory()->createOne();
+
+    $this->actingAs($this->actor);
+});
+
+test('hasEngaged reflects whether the actor engaged the target with a Verb', function (): void {
+    $this->target->like();
+
+    expect($this->actor->hasEngaged($this->target, EngagementTypes::Like))->toBeTrue()
+        ->and($this->actor->hasEngaged($this->target, EngagementTypes::Dislike))->toBeFalse();
+});
+
+test('engagementValueFor returns the typed value of a weighted engagement', function (): void {
+    config(['engageify.types' => Vote::class]);
+
+    $this->target->engage(Vote::Up);
+
+    expect($this->actor->engagementValueFor($this->target, Vote::Up))->toBe(1.0);
+});
+
+test('engagementValueFor returns null for a binary engagement', function (): void {
+    $this->target->like();
+
+    expect($this->actor->engagementValueFor($this->target, EngagementTypes::Like))->toBeNull();
+});
+
+test('ratingFor returns the actor\'s rating of the target', function (): void {
+    config(['engageify.types' => Rating::class]);
+
+    $this->target->engage(Rating::Stars, 4);
+
+    expect($this->actor->ratingFor($this->target, Rating::Stars))->toBe(4.0);
+});
+
+test('the actor relation returns the engagements the actor authored', function (): void {
+    $other = User::factory()->createOne();
+
+    $this->target->like();
+    $other->like();
+
+    expect($this->actor->authoredEngagements)->toHaveCount(2);
+});
+
+test('withUserEngagement attaches feed-state for N rows in a single query', function (): void {
+    $engaged = User::factory()->createOne();
+    $notEngaged = User::factory()->createOne();
+
+    $engaged->like();
+
+    $queries = 0;
+    DB::listen(function () use (&$queries): void {
+        $queries++;
+    });
+
+    $feed = User::query()
+        ->whereIn('id', [$engaged->id, $notEngaged->id])
+        ->withUserEngagement(EngagementTypes::Like)
+        ->get();
+
+    expect($queries)->toBe(1)
+        ->and($feed->firstWhere('id', $engaged->id)->is_engaged)->toBeTrue()
+        ->and($feed->firstWhere('id', $notEngaged->id)->is_engaged)->toBeFalse();
+});
+
+test('withUserEngagement accepts an explicit actor', function (): void {
+    $otherActor = User::factory()->createOne();
+
+    $this->target->like();
+
+    $forActor = User::query()->whereKey($this->target->id)->withUserEngagement(EngagementTypes::Like, $this->actor)->first();
+    $forOther = User::query()->whereKey($this->target->id)->withUserEngagement(EngagementTypes::Like, $otherActor)->first();
+
+    expect($forActor->is_engaged)->toBeTrue()
+        ->and($forOther->is_engaged)->toBeFalse();
+});
+
+test('withUserEngagement attaches the typed value for a Rateable Verb', function (): void {
+    config(['engageify.types' => Rating::class]);
+
+    $this->target->engage(Rating::Stars, 4);
+
+    $row = User::query()->whereKey($this->target->id)->withUserEngagement(Rating::Stars)->first();
+
+    expect($row->is_engaged)->toBeTrue()
+        ->and((float) $row->engagement_value)->toBe(4.0);
+});

--- a/tests/Fixtures/User.php
+++ b/tests/Fixtures/User.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Cjmellor\Engageify\Tests\Fixtures;
 
+use Cjmellor\Engageify\Concerns\EngagesWith;
 use Cjmellor\Engageify\Concerns\HasEngagements;
 use Cjmellor\Engageify\Tests\Fixtures\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Attributes\Table;
@@ -14,7 +15,10 @@ use Illuminate\Foundation\Auth\User as Authenticatable;
 #[Table(name: 'users')]
 class User extends Authenticatable
 {
-    use HasEngagements;
+    use EngagesWith, HasEngagements {
+        HasEngagements::engagements insteadof EngagesWith;
+        EngagesWith::engagements as authoredEngagements;
+    }
     use HasFactory;
 
     protected $guarded = [];


### PR DESCRIPTION
Implements #34.

## What

- Opt-in `EngagesWith` trait for the actor model: `engagements()` relation, `hasEngaged($target, $type)`, `engagementValueFor($target, $type)` (typed value or `null`), `ratingFor()` alias.
- `withUserEngagement($type, ?$user = null)` correlated-subquery scope on engageables: attaches a typed `is_engaged` boolean (+ `engagement_value` for `Rateable`) per row in **one query**, defaulting `$user` to the auth user.

## Acceptance criteria

- [x] `$user->hasEngaged`/`engagementValueFor`/`ratingFor` return correct results
- [x] `withUserEngagement` resolves feed-state for N rows in a single query (test asserts query count == 1)
- [x] Defaults to the auth user; accepts an explicit actor
- [x] 100% code + type coverage

The test `User` fixture is intentionally dual-role (actor + engageable), demonstrating the trait-conflict resolution consumers would use when one model plays both parts.

Full suite green: 72 tests / 134 assertions, 100% code + type coverage, larastan level 5 clean, Pint + Rector clean.