### PR TITLE
[2.x] Views: count-only subsystem, Fingerprint + cooldown dedup, opt-in daily buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,38 @@ This will return a Collection of Users who liked the Model.
 
 This works on all 4 fetch methods.
 
+## View Tracking
+
+Views are a **count-only** subsystem — separate from engagement Verbs, with no per-view rows. Add the `HasViews` trait to anything you want to count views on, and record a view explicitly (you decide what counts — skip authors, bots, API hits):
+
+```php
+use Cjmellor\Engageify\Concerns\HasViews;
+
+class Thread extends Model
+{
+    use HasViews;
+}
+```
+
+```php
+$thread->recordView();          // counts once per viewer per cooldown window
+$thread->viewCount();           // lifetime total
+Thread::query()->orderByMostViewed()->get(); // most viewed, all-time
+```
+
+Viewers are deduplicated by a **fingerprint** — the authenticated user id, or a SHA-256 hash of IP + user agent for anonymous traffic (the raw IP is never stored). A repeat view inside `engageify.views.cooldown` seconds doesn't count again.
+
+### Time-windowed views (opt-in)
+
+A lifetime total is always kept. For "views this week"/trending you must opt into a per-day bucket table by setting `engageify.views.buckets` to `true` (or `ENGAGEIFY_VIEW_BUCKETS=true`):
+
+```php
+$thread->viewsInLast(7);                            // views in the last 7 days
+Thread::query()->orderByMostViewed('week')->get();  // most viewed this week
+```
+
+> **Buckets can't be backfilled.** While `buckets` is off, only the lifetime total exists — there's no per-day history to reconstruct. If you might ever want windows or trending, enable buckets from day one.
+
 ## Events
 
 Two generic events are dispatched for every engagement, regardless of the Verb.

--- a/config/engageify.php
+++ b/config/engageify.php
@@ -51,4 +51,23 @@ return [
     |
     */
     'bayesian_minimum' => env(key: 'ENGAGEIFY_BAYESIAN_MINIMUM', default: 5),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Views
+    |--------------------------------------------------------------------------
+    |
+    | View tracking is a count-only subsystem. `cooldown` is the number of
+    | seconds a fingerprint is deduplicated for (repeat views inside the window
+    | don't count). `buckets` opts into a per-day time-series table powering
+    | viewsInLast()/orderByMostViewed($period).
+    |
+    | CAUTION: buckets cannot be backfilled — while off, only the lifetime total
+    | is kept, so enable it from day one if you may ever want windows/trending.
+    |
+    */
+    'views' => [
+        'cooldown' => env(key: 'ENGAGEIFY_VIEW_COOLDOWN', default: 3600),
+        'buckets' => env(key: 'ENGAGEIFY_VIEW_BUCKETS', default: false),
+    ],
 ];

--- a/database/migrations/2026_05_31_000003_create_view_buckets_table.php
+++ b/database/migrations/2026_05_31_000003_create_view_buckets_table.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('view_buckets', function (Blueprint $table): void {
+            $table->id();
+            $table->morphs(name: 'viewable');
+            $table->date(column: 'date');
+            $table->unsignedBigInteger(column: 'count')->default(0);
+            $table->timestamps();
+
+            $table->unique(columns: ['viewable_type', 'viewable_id', 'date']);
+        });
+    }
+};

--- a/src/Concerns/HasEngagements.php
+++ b/src/Concerns/HasEngagements.php
@@ -121,7 +121,7 @@ trait HasEngagements
                 'value' => $resolved,
             ]);
 
-            EngagementCounter::record(engageable: $this, type: $type, countDelta: 1, valueDelta: (float) ($resolved ?? 0));
+            EngagementCounter::record(engageable: $this, type: $type->value, countDelta: 1, valueDelta: (float) ($resolved ?? 0));
 
             event(new Engaged(actor: auth()->user(), engageable: $this, type: $type, engagement: $engagement));
 
@@ -162,7 +162,7 @@ trait HasEngagements
 
                 EngagementCounter::record(
                     engageable: $this,
-                    type: $type,
+                    type: $type->value,
                     countDelta: -$engagements->count(),
                     valueDelta: -(float) $engagements->sum(fn (Engagement $engagement): float => (float) $engagement->value),
                 );
@@ -423,7 +423,7 @@ trait HasEngagements
         $existing->each(function (Engagement $engagement): void {
             $engagement->delete();
 
-            EngagementCounter::record(engageable: $this, type: $engagement->type, countDelta: -1, valueDelta: -(float) $engagement->value);
+            EngagementCounter::record(engageable: $this, type: $engagement->type->value, countDelta: -1, valueDelta: -(float) $engagement->value);
 
             event(new Disengaged(actor: auth()->user(), engageable: $this, type: $engagement->type));
         });
@@ -440,7 +440,7 @@ trait HasEngagements
             'value' => $resolved,
         ]);
 
-        EngagementCounter::record(engageable: $this, type: $type, countDelta: 1, valueDelta: (float) ($resolved ?? 0));
+        EngagementCounter::record(engageable: $this, type: $type->value, countDelta: 1, valueDelta: (float) ($resolved ?? 0));
 
         event(new Engaged(actor: auth()->user(), engageable: $this, type: $type, engagement: $engagement));
 
@@ -479,7 +479,7 @@ trait HasEngagements
 
                 $existing->update(['value' => $validated]);
 
-                EngagementCounter::record(engageable: $this, type: $type, countDelta: 0, valueDelta: $validated - $previous);
+                EngagementCounter::record(engageable: $this, type: $type->value, countDelta: 0, valueDelta: $validated - $previous);
 
                 $engagement = $existing;
             } else {
@@ -489,7 +489,7 @@ trait HasEngagements
                     'value' => $validated,
                 ]);
 
-                EngagementCounter::record(engageable: $this, type: $type, countDelta: 1, valueDelta: $validated);
+                EngagementCounter::record(engageable: $this, type: $type->value, countDelta: 1, valueDelta: $validated);
             }
 
             event(new Engaged(actor: auth()->user(), engageable: $this, type: $type, engagement: $engagement));

--- a/src/Concerns/HasViews.php
+++ b/src/Concerns/HasViews.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cjmellor\Engageify\Concerns;
+
+use Cjmellor\Engageify\Models\EngagementCounter;
+use Cjmellor\Engageify\Models\ViewBucket;
+use Cjmellor\Engageify\Support\ViewRecorder;
+use Illuminate\Database\Eloquent\Builder;
+
+trait HasViews
+{
+    public function recordView(): void
+    {
+        ViewRecorder::record(viewable: $this);
+    }
+
+    public function viewCount(): int
+    {
+        return (int) EngagementCounter::query()
+            ->where('engagementable_type', $this->getMorphClass())
+            ->where('engagementable_id', $this->getKey())
+            ->where('type', ViewRecorder::TYPE)
+            ->sum(column: 'count');
+    }
+
+    public function viewsInLast(int $days): int
+    {
+        return (int) ViewBucket::query()
+            ->where('viewable_type', $this->getMorphClass())
+            ->where('viewable_id', $this->getKey())
+            ->where('date', '>=', today()->subDays($days))
+            ->sum(column: 'count');
+    }
+
+    /**
+     * @param  Builder<static>  $query
+     * @return Builder<static>
+     */
+    protected function scopeOrderByMostViewed(Builder $query, ?string $period = null, string $direction = 'desc'): Builder
+    {
+        $model = $query->getModel();
+
+        if ($period === null) {
+            return $query
+                ->leftJoinSub(
+                    EngagementCounter::query()
+                        ->select(['engagementable_id', 'count'])
+                        ->where('engagementable_type', $model->getMorphClass())
+                        ->where('type', ViewRecorder::TYPE),
+                    'view_totals',
+                    'view_totals.engagementable_id',
+                    '=',
+                    $model->getQualifiedKeyName(),
+                )
+                ->orderBy('view_totals.count', $direction)
+                ->select("{$model->getTable()}.*");
+        }
+
+        return $query
+            ->leftJoinSub(
+                ViewBucket::query()
+                    ->selectRaw('viewable_id, sum(count) as views')
+                    ->where('viewable_type', $model->getMorphClass())
+                    ->where('date', '>=', today()->sub("1 {$period}"))
+                    ->groupBy('viewable_id'),
+                'view_window',
+                'view_window.viewable_id',
+                '=',
+                $model->getQualifiedKeyName(),
+            )
+            ->orderBy('view_window.views', $direction)
+            ->select("{$model->getTable()}.*");
+    }
+}

--- a/src/Models/EngagementCounter.php
+++ b/src/Models/EngagementCounter.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Cjmellor\Engageify\Models;
 
-use Cjmellor\Engageify\Contracts\EngagementType;
 use Cjmellor\Engageify\Support\HotScore;
 use DateTimeInterface;
 use Illuminate\Database\Eloquent\Model;
@@ -20,12 +19,12 @@ class EngagementCounter extends Model
 {
     protected $guarded = [];
 
-    public static function record(Model $engageable, EngagementType $type, int $countDelta, int|float $valueDelta): void
+    public static function record(Model $engageable, string $type, int $countDelta, int|float $valueDelta): void
     {
         $counter = static::query()->firstOrCreate([
             'engagementable_type' => $engageable->getMorphClass(),
             'engagementable_id' => $engageable->getKey(),
-            'type' => $type->value,
+            'type' => $type,
         ]);
 
         $counter->increment(column: 'count', amount: $countDelta);

--- a/src/Models/ViewBucket.php
+++ b/src/Models/ViewBucket.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cjmellor\Engageify\Models;
+
+use DateTimeInterface;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property int $count
+ */
+class ViewBucket extends Model
+{
+    protected $guarded = [];
+
+    public static function record(Model $viewable, DateTimeInterface $date): void
+    {
+        $bucket = static::query()->firstOrCreate([
+            'viewable_type' => $viewable->getMorphClass(),
+            'viewable_id' => $viewable->getKey(),
+            'date' => $date,
+        ]);
+
+        $bucket->increment(column: 'count');
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'date' => 'date',
+            'count' => 'integer',
+        ];
+    }
+}

--- a/src/Support/Fingerprint.php
+++ b/src/Support/Fingerprint.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cjmellor\Engageify\Support;
+
+class Fingerprint
+{
+    public static function make(int|string|null $userId, ?string $ip, ?string $userAgent): string
+    {
+        if ($userId !== null) {
+            return 'user:'.$userId;
+        }
+
+        return 'anon:'.hash(algo: 'sha256', data: ($ip ?? '').'|'.($userAgent ?? ''));
+    }
+}

--- a/src/Support/ViewRecorder.php
+++ b/src/Support/ViewRecorder.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cjmellor\Engageify\Support;
+
+use Cjmellor\Engageify\Models\EngagementCounter;
+use Cjmellor\Engageify\Models\ViewBucket;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Cache;
+
+class ViewRecorder
+{
+    public const TYPE = 'view';
+
+    public static function record(Model $viewable): void
+    {
+        $fingerprint = Fingerprint::make(
+            userId: auth()->id(),
+            ip: request()->ip(),
+            userAgent: request()->userAgent(),
+        );
+
+        $key = 'view:'.$fingerprint.':'.$viewable->getMorphClass().':'.$viewable->getKey();
+
+        if (! Cache::add(key: $key, value: true, ttl: (int) config(key: 'engageify.views.cooldown'))) {
+            return;
+        }
+
+        EngagementCounter::record(engageable: $viewable, type: self::TYPE, countDelta: 1, valueDelta: 0);
+
+        if (config(key: 'engageify.views.buckets')) {
+            ViewBucket::record(viewable: $viewable, date: today());
+        }
+    }
+}

--- a/tests/Concerns/HasViewsTest.php
+++ b/tests/Concerns/HasViewsTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+use Cjmellor\Engageify\Models\Engagement;
+use Cjmellor\Engageify\Models\ViewBucket;
+use Cjmellor\Engageify\Tests\Fixtures\User;
+
+test('recordView counts once per fingerprint per cooldown; repeats within the window do not count', function (): void {
+    $post = User::factory()->createOne();
+
+    $this->actingAs($this->user);
+    $post->recordView();
+    $post->recordView();
+
+    expect($post->viewCount())->toBe(1);
+});
+
+test('distinct viewers are counted separately', function (): void {
+    $post = User::factory()->createOne();
+    $viewerA = User::factory()->createOne();
+    $viewerB = User::factory()->createOne();
+
+    $this->actingAs($viewerA);
+    $post->recordView();
+
+    $this->actingAs($viewerB);
+    $post->recordView();
+
+    expect($post->viewCount())->toBe(2);
+});
+
+test('recording a view writes no per-view engagement row', function (): void {
+    $post = User::factory()->createOne();
+
+    $this->actingAs($this->user);
+    $post->recordView();
+
+    $this->assertDatabaseCount(Engagement::class, 0);
+
+    expect($post->viewCount())->toBe(1);
+});
+
+test('with buckets off only the lifetime total is kept', function (): void {
+    config(['engageify.views.buckets' => false]);
+
+    $post = User::factory()->createOne();
+
+    $this->actingAs($this->user);
+    $post->recordView();
+
+    $this->assertDatabaseCount(ViewBucket::class, 0);
+
+    expect($post->viewCount())->toBe(1);
+});
+
+test('with buckets on daily rows are written and viewsInLast works', function (): void {
+    config(['engageify.views.buckets' => true]);
+
+    $post = User::factory()->createOne();
+
+    $this->actingAs($this->user);
+    $post->recordView();
+
+    $this->assertDatabaseCount(ViewBucket::class, 1);
+
+    expect($post->viewsInLast(7))->toBe(1);
+});
+
+test('orderByMostViewed ranks by the lifetime total', function (): void {
+    $popular = User::factory()->createOne();
+    $quiet = User::factory()->createOne();
+
+    foreach (User::factory()->count(3)->create() as $viewer) {
+        $this->actingAs($viewer);
+        $popular->recordView();
+    }
+
+    $this->actingAs($this->user);
+    $quiet->recordView();
+
+    $ordered = User::query()->whereIn('id', [$popular->id, $quiet->id])->orderByMostViewed()->pluck('id');
+
+    expect($ordered->all())->toBe([$popular->id, $quiet->id]);
+});
+
+test('orderByMostViewed with a period ranks by views within the window only', function (): void {
+    config(['engageify.views.buckets' => true]);
+
+    $popular = User::factory()->createOne();
+    $quiet = User::factory()->createOne();
+
+    $viewers = User::factory()->count(2)->create();
+    foreach ($viewers as $viewer) {
+        $this->actingAs($viewer);
+        $popular->recordView();
+    }
+
+    $this->actingAs($this->user);
+    $quiet->recordView();
+
+    ViewBucket::query()->create([
+        'viewable_type' => $quiet->getMorphClass(),
+        'viewable_id' => $quiet->id,
+        'date' => now()->subMonths(2),
+        'count' => 100,
+    ]);
+
+    $ordered = User::query()->whereIn('id', [$popular->id, $quiet->id])->orderByMostViewed('week')->pluck('id');
+
+    expect($ordered->all())->toBe([$popular->id, $quiet->id]);
+});

--- a/tests/Fixtures/User.php
+++ b/tests/Fixtures/User.php
@@ -6,6 +6,7 @@ namespace Cjmellor\Engageify\Tests\Fixtures;
 
 use Cjmellor\Engageify\Concerns\EngagesWith;
 use Cjmellor\Engageify\Concerns\HasEngagements;
+use Cjmellor\Engageify\Concerns\HasViews;
 use Cjmellor\Engageify\Tests\Fixtures\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Factories\Factory;
@@ -20,6 +21,7 @@ class User extends Authenticatable
         EngagesWith::engagements as authoredEngagements;
     }
     use HasFactory;
+    use HasViews;
 
     protected $guarded = [];
 

--- a/tests/Support/FingerprintTest.php
+++ b/tests/Support/FingerprintTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use Cjmellor\Engageify\Support\Fingerprint;
+
+test('Fingerprint uses the user id when authenticated', function (): void {
+    expect(Fingerprint::make(42, '1.2.3.4', 'Mozilla/5.0'))->toBe('user:42');
+});
+
+test('Fingerprint hashes an anonymous viewer\'s IP and user agent, never storing them raw', function (): void {
+    $fingerprint = Fingerprint::make(null, '1.2.3.4', 'Mozilla/5.0');
+
+    expect($fingerprint)->toStartWith('anon:')
+        ->and($fingerprint)->not->toContain('1.2.3.4')
+        ->and($fingerprint)->toBe('anon:'.hash('sha256', '1.2.3.4|Mozilla/5.0'));
+});
+
+test('Fingerprint tolerates a missing IP and user agent', function (): void {
+    expect(Fingerprint::make(null, null, null))->toBe('anon:'.hash('sha256', '|'));
+});


### PR DESCRIPTION
Implements #35.

## What

- `HasViews` trait: `recordView()`, `viewCount()`, `viewsInLast($days)`, `orderByMostViewed($period)`.
- Pure `Fingerprint` (auth id, else SHA-256 hash of IP+UA — never stored raw).
- `ViewRecorder`: dedups via atomic `Cache::add("view:{fingerprint}:{engageable}", $cooldown)` and increments the shared `engagement_counters` total under a `'view'` type **only on first sighting per cooldown** — no per-view rows.
- Opt-in `view_buckets` table (`viewable, date, count`), **default off** via `engageify.views.buckets`, powering `viewsInLast`/`orderByMostViewed($period)`.
- `EngagementCounter::record()` now takes a string type so views and engagements share it.

## Acceptance criteria

- [x] `recordView` increments the total once per fingerprint per cooldown; repeats within the window don't count
- [x] Anonymous viewers deduped by hashed fingerprint; raw IP never stored
- [x] Buckets off → only the total; buckets on → daily rows + `viewsInLast`/`orderByMostViewed`
- [x] No per-view engagement rows written; config documented incl. backfill caution
- [x] 100% code + type coverage

Full suite green: 94 tests / 167 assertions, 100% code + type coverage, larastan level 5 clean, Pint + Rector clean.

See ADR-0007 (views/impressions are a count-only subsystem).