### PR TITLE
[2.x] Impression backend: signed ImpressionToken, @impression directive, verified endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,20 @@ Thread::query()->orderByMostViewed('week')->get();  // most viewed this week
 
 > **Buckets can't be backfilled.** While `buckets` is off, only the lifetime total exists — there's no per-day history to reconstruct. If you might ever want windows or trending, enable buckets from day one.
 
+### Impressions (viewport)
+
+A *view* is server-detectable; an *impression* (was the element actually on screen) can only be measured in the browser. Engageify ships the secure backend for it. Mark an element with the `@impression` directive, which emits a data attribute carrying an **app-key-signed token** (HMAC of `type:id` + expiry):
+
+```blade
+<article @impression($thread)>
+    ...
+</article>
+```
+
+A browser posts that token to the impression endpoint (default `POST /engageify/impressions`), which **verifies the signature** before counting — so only server-rendered, unexpired elements can report an impression. It's layered with the same fingerprint dedup as views and is route-throttled. Forged, tampered, or expired tokens are rejected without counting. Impressions accumulate on the same count-only counter (no per-impression rows).
+
+Configure the endpoint, throttle and token lifetime under `engageify.impressions`. (The viewport-detection script that posts these tokens ships with the frontend integration.)
+
 ## Events
 
 Two generic events are dispatched for every engagement, regardless of the Verb.

--- a/config/engageify.php
+++ b/config/engageify.php
@@ -70,4 +70,21 @@ return [
         'cooldown' => env(key: 'ENGAGEIFY_VIEW_COOLDOWN', default: 3600),
         'buckets' => env(key: 'ENGAGEIFY_VIEW_BUCKETS', default: false),
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Impressions
+    |--------------------------------------------------------------------------
+    |
+    | Viewport-impression tracking. `endpoint` is the route the browser posts a
+    | signed token to; `throttle` is its rate limit (Laravel `maxAttempts,
+    | decayMinutes`); `token_ttl` is how long a signed impression token stays
+    | valid, in seconds.
+    |
+    */
+    'impressions' => [
+        'endpoint' => env(key: 'ENGAGEIFY_IMPRESSION_ENDPOINT', default: 'engageify/impressions'),
+        'throttle' => env(key: 'ENGAGEIFY_IMPRESSION_THROTTLE', default: '60,1'),
+        'token_ttl' => env(key: 'ENGAGEIFY_IMPRESSION_TOKEN_TTL', default: 86400),
+    ],
 ];

--- a/src/EngageifyServiceProvider.php
+++ b/src/EngageifyServiceProvider.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Cjmellor\Engageify;
 
 use Cjmellor\Engageify\Commands\RecountCommand;
+use Cjmellor\Engageify\Http\Controllers\ImpressionController;
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 
 class EngageifyServiceProvider extends ServiceProvider
@@ -25,6 +28,10 @@ class EngageifyServiceProvider extends ServiceProvider
             ]);
         }
 
+        $this->registerImpressionRoute();
+
+        Blade::directive('impression', fn (string $expression): string => "<?php echo \Cjmellor\Engageify\Support\ImpressionToken::attribute({$expression}); ?>");
+
         $this->publishes([
             __DIR__.'/../config/engageify.php' => config_path(path: 'engageify.php'),
         ], groups: 'engageify-config');
@@ -32,5 +39,12 @@ class EngageifyServiceProvider extends ServiceProvider
         $this->publishesMigrations([
             __DIR__.'/../database/migrations' => database_path(path: 'migrations'),
         ], groups: 'engageify-migrations');
+    }
+
+    protected function registerImpressionRoute(): void
+    {
+        Route::middleware('throttle:'.config(key: 'engageify.impressions.throttle'))
+            ->post((string) config(key: 'engageify.impressions.endpoint'), ImpressionController::class)
+            ->name('engageify.impressions');
     }
 }

--- a/src/Http/Controllers/ImpressionController.php
+++ b/src/Http/Controllers/ImpressionController.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cjmellor\Engageify\Http\Controllers;
+
+use Cjmellor\Engageify\Support\ImpressionRecorder;
+use Cjmellor\Engageify\Support\ImpressionToken;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+class ImpressionController
+{
+    public function __invoke(Request $request): Response
+    {
+        $verified = ImpressionToken::verify(token: (string) $request->input('token'));
+
+        abort_if($verified === null, code: Response::HTTP_FORBIDDEN);
+
+        ImpressionRecorder::record(morphType: $verified['type'], morphId: $verified['id']);
+
+        return response()->noContent();
+    }
+}

--- a/src/Models/EngagementCounter.php
+++ b/src/Models/EngagementCounter.php
@@ -43,6 +43,15 @@ class EngagementCounter extends Model
         }
     }
 
+    public static function tally(string $engagementableType, int|string $engagementableId, string $type): void
+    {
+        static::query()->firstOrCreate([
+            'engagementable_type' => $engagementableType,
+            'engagementable_id' => $engagementableId,
+            'type' => $type,
+        ])->increment(column: 'count');
+    }
+
     public static function rebuild(): void
     {
         static::query()->delete();

--- a/src/Support/ImpressionRecorder.php
+++ b/src/Support/ImpressionRecorder.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cjmellor\Engageify\Support;
+
+use Cjmellor\Engageify\Models\EngagementCounter;
+use Illuminate\Support\Facades\Cache;
+
+class ImpressionRecorder
+{
+    public const TYPE = 'impression';
+
+    public static function record(string $morphType, int|string $morphId): void
+    {
+        $fingerprint = Fingerprint::make(
+            userId: auth()->id(),
+            ip: request()->ip(),
+            userAgent: request()->userAgent(),
+        );
+
+        $key = 'impression:'.$fingerprint.':'.$morphType.':'.$morphId;
+
+        if (! Cache::add(key: $key, value: true, ttl: (int) config(key: 'engageify.views.cooldown'))) {
+            return;
+        }
+
+        EngagementCounter::tally(engagementableType: $morphType, engagementableId: $morphId, type: self::TYPE);
+    }
+}

--- a/src/Support/ImpressionToken.php
+++ b/src/Support/ImpressionToken.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cjmellor\Engageify\Support;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ImpressionToken
+{
+    public static function generate(Model $model, int $ttl): string
+    {
+        $payload = $model->getMorphClass().'|'.$model->getKey().'|'.(now()->getTimestamp() + $ttl);
+
+        return self::encode(value: $payload).'.'.self::sign(payload: $payload);
+    }
+
+    public static function attribute(Model $model): string
+    {
+        $token = self::generate(model: $model, ttl: (int) config(key: 'engageify.impressions.token_ttl'));
+
+        return 'data-engageify-impression="'.e($token).'"';
+    }
+
+    /**
+     * @return array{type: string, id: string}|null
+     */
+    public static function verify(string $token): ?array
+    {
+        [$encoded, $signature] = array_pad(explode('.', $token, 2), 2, '');
+
+        $payload = base64_decode(strtr($encoded, '-_', '+/')) ?: '';
+
+        if (! hash_equals(self::sign(payload: $payload), $signature)) {
+            return null;
+        }
+
+        [$type, $id, $expiresAt] = array_pad(explode('|', $payload, 3), 3, '');
+
+        if ($type === '' || $id === '' || $expiresAt === '' || (int) $expiresAt < now()->getTimestamp()) {
+            return null;
+        }
+
+        return ['type' => $type, 'id' => $id];
+    }
+
+    private static function sign(string $payload): string
+    {
+        return hash_hmac('sha256', $payload, (string) config(key: 'app.key'));
+    }
+
+    private static function encode(string $value): string
+    {
+        return rtrim(strtr(base64_encode($value), '+/', '-_'), '=');
+    }
+}

--- a/tests/Feature/ImpressionEndpointTest.php
+++ b/tests/Feature/ImpressionEndpointTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+use Cjmellor\Engageify\Models\EngagementCounter;
+use Cjmellor\Engageify\Support\ImpressionRecorder;
+use Cjmellor\Engageify\Support\ImpressionToken;
+use Cjmellor\Engageify\Tests\Fixtures\User;
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\Route;
+
+function impressionCount(User $model): int
+{
+    return (int) EngagementCounter::query()
+        ->where('engagementable_type', $model->getMorphClass())
+        ->where('engagementable_id', $model->id)
+        ->where('type', ImpressionRecorder::TYPE)
+        ->sum('count');
+}
+
+test('@impression renders a data attribute carrying a valid signed token', function (): void {
+    $model = User::factory()->createOne();
+
+    $html = Blade::render('@impression($model)', ['model' => $model]);
+
+    expect($html)->toStartWith('data-engageify-impression="');
+
+    preg_match('/data-engageify-impression="([^"]+)"/', $html, $matches);
+
+    expect(ImpressionToken::verify($matches[1]))->toBe(['type' => $model->getMorphClass(), 'id' => (string) $model->id]);
+});
+
+test('the endpoint accepts a valid token and counts one impression', function (): void {
+    $model = User::factory()->createOne();
+
+    $this->postJson(route('engageify.impressions'), ['token' => ImpressionToken::generate($model, 3600)])
+        ->assertNoContent();
+
+    expect(impressionCount($model))->toBe(1);
+});
+
+test('the endpoint dedups repeat impressions within the cooldown', function (): void {
+    $model = User::factory()->createOne();
+    $token = ImpressionToken::generate($model, 3600);
+
+    $this->postJson(route('engageify.impressions'), ['token' => $token])->assertNoContent();
+    $this->postJson(route('engageify.impressions'), ['token' => $token])->assertNoContent();
+
+    expect(impressionCount($model))->toBe(1);
+});
+
+test('the endpoint rejects a forged token without counting', function (): void {
+    $model = User::factory()->createOne();
+
+    $this->postJson(route('engageify.impressions'), ['token' => 'forged.token'])
+        ->assertForbidden();
+
+    expect(impressionCount($model))->toBe(0);
+});
+
+test('the impression endpoint is throttled', function (): void {
+    $route = Route::getRoutes()->getByName('engageify.impressions');
+
+    expect($route->gatherMiddleware())->toContain('throttle:60,1');
+});

--- a/tests/Support/ImpressionTokenTest.php
+++ b/tests/Support/ImpressionTokenTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use Cjmellor\Engageify\Support\ImpressionToken;
+use Cjmellor\Engageify\Tests\Fixtures\User;
+
+test('a generated token verifies and returns the model type and id', function (): void {
+    $model = User::factory()->createOne();
+
+    $verified = ImpressionToken::verify(ImpressionToken::generate($model, 3600));
+
+    expect($verified)->toBe(['type' => $model->getMorphClass(), 'id' => (string) $model->id]);
+});
+
+test('a tampered token is rejected', function (): void {
+    $model = User::factory()->createOne();
+
+    $token = ImpressionToken::generate($model, 3600);
+
+    expect(ImpressionToken::verify($token.'tampered'))->toBeNull();
+});
+
+test('an expired token is rejected', function (): void {
+    $model = User::factory()->createOne();
+
+    expect(ImpressionToken::verify(ImpressionToken::generate($model, -10)))->toBeNull();
+});
+
+test('a malformed token is rejected', function (): void {
+    expect(ImpressionToken::verify('not-a-real-token'))->toBeNull();
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -25,6 +25,7 @@ class TestCase extends Orchestra
 
     protected function getEnvironmentSetUp($app): void
     {
+        $app['config']->set('app.key', 'base64:'.base64_encode(str_repeat('a', 32)));
         $app['config']->set('database.default', 'sqlite');
         $app['config']->set('database.connections.sqlite', [
             'driver' => 'sqlite',


### PR DESCRIPTION
Implements #36.

## What

- Pure `ImpressionToken`: signs/verifies HMAC of `type:id` + expiry with the app key.
- `@impression($model)` Blade directive emitting the element's signed data attribute.
- A verified impression **endpoint** (`POST /engageify/impressions`, configurable): verifies the token, applies `Fingerprint` + cooldown dedup (reusing the Views machinery), is route-throttled, and increments the count-only impression counter — no per-impression rows.

## Acceptance criteria

- [x] `@impression` renders a data attribute with a valid signed token for the model
- [x] Endpoint accepts a valid, unexpired token and counts one impression (deduped per fingerprint/cooldown)
- [x] Endpoint rejects forged, tampered, or expired tokens without counting
- [x] Endpoint is throttled; 100% coverage

The browser viewport-detection script + injecting middleware (ADR-0008) are the frontend slice (#37, HITL).

Full suite green: 103 tests / 184 assertions, 100% code + type coverage, larastan level 5 clean, Pint + Rector clean.

See ADR-0008 (impression tracking ships browser JS with no consumer build step).