### PR TITLE
[2.x] Make EngagementFactory consumer-safe

### DIFF
--- a/database/factories/EngagementFactory.php
+++ b/database/factories/EngagementFactory.php
@@ -5,46 +5,52 @@ declare(strict_types=1);
 namespace Cjmellor\Engageify\Database\Factories;
 
 use Cjmellor\Engageify\Models\Engagement;
-use Cjmellor\Engageify\Tests\Fixtures\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Model;
 
 class EngagementFactory extends Factory
 {
     protected $model = Engagement::class;
 
+    /**
+     * @return array<string, mixed>
+     */
     public function definition(): array
     {
+        /** @var class-string<Model> $engageable */
+        $engageable = config(key: 'engageify.users.model');
+
         return [
-            'engagementable_id' => User::factory()->createOne()->id,
-            'engagementable_type' => User::class,
-            'user_id' => User::factory(),
+            'engagementable_id' => $engageable::factory(), // @phpstan-ignore staticMethod.notFound
+            'engagementable_type' => (new $engageable)->getMorphClass(),
+            'user_id' => $engageable::factory(), // @phpstan-ignore staticMethod.notFound
         ];
     }
 
     public function like(): Factory
     {
-        return $this->state(fn (array $attributes): array => [
+        return $this->state(fn (): array => [
             'type' => 'like',
         ]);
     }
 
     public function dislike(): Factory
     {
-        return $this->state(fn (array $attributes): array => [
+        return $this->state(fn (): array => [
             'type' => 'dislike',
         ]);
     }
 
     public function upvote(): Factory
     {
-        return $this->state(fn (array $attributes): array => [
+        return $this->state(fn (): array => [
             'type' => 'upvote',
         ]);
     }
 
     public function downvote(): Factory
     {
-        return $this->state(fn (array $attributes): array => [
+        return $this->state(fn (): array => [
             'type' => 'downvote',
         ]);
     }

--- a/src/Models/Engagement.php
+++ b/src/Models/Engagement.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Cjmellor\Engageify\Models;
 
 use Cjmellor\Engageify\Contracts\EngagementType;
+use Cjmellor\Engageify\Database\Factories\EngagementFactory;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -28,6 +30,11 @@ class Engagement extends Model
     public function user(): BelongsTo
     {
         return $this->belongsTo(config(key: 'engageify.users.model'));
+    }
+
+    protected static function newFactory(): Factory
+    {
+        return EngagementFactory::new();
     }
 
     /**

--- a/tests/Arch.php
+++ b/tests/Arch.php
@@ -7,3 +7,8 @@ test('Arch tests')
     ->each
     ->not
     ->toBeUsed();
+
+test('shipped factories do not depend on test fixtures')
+    ->expect('Cjmellor\Engageify\Database\Factories')
+    ->not
+    ->toUse('Cjmellor\Engageify\Tests');

--- a/tests/Feature/EngagementFactoryTest.php
+++ b/tests/Feature/EngagementFactoryTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Cjmellor\Engageify\Enums\EngagementTypes;
+use Cjmellor\Engageify\Models\Engagement;
+use Cjmellor\Engageify\Tests\Fixtures\User;
+
+it('builds a persistable engagement from the configured user model', function (): void {
+    config()->set('engageify.users.model', User::class);
+
+    $engagement = Engagement::factory()->like()->create();
+
+    expect($engagement->exists)->toBeTrue()
+        ->and($engagement->type)->toBe(EngagementTypes::Like)
+        ->and($engagement->user_id)->not->toBeNull()
+        ->and($engagement->engagementable_type)->toBe((new User)->getMorphClass());
+});
+
+it('honours the configured user model rather than a hardcoded fixture', function (): void {
+    config()->set('engageify.users.model', User::class);
+
+    $engagement = Engagement::factory()->upvote()->create();
+
+    expect($engagement->engagementable_type)->toBe((new User)->getMorphClass())
+        ->and(User::query()->whereKey($engagement->user_id)->exists())->toBeTrue();
+});


### PR DESCRIPTION
Closes #54.

## What & why

The shipped `EngagementFactory` referenced the **export-ignored** test `User` fixture (`Cjmellor\Engageify\Tests\Fixtures\User`), so in a published install `Engagement::factory()` fatalled with a class-not-found error. While fixing it I also found `Engagement::factory()` was **never resolvable at all** in a package context — the model had no `newFactory()`, so Laravel guessed a wrong FQCN (`Database\Factories\Cjmellor\Engageify\Models\EngagementFactory`) and threw. (Nothing in the suite had ever called it, so this was latent.)

## Changes

- **`EngagementFactory::definition()` is now config-driven** — resolves the engageable and actor from `engageify.users.model` instead of importing the test fixture. The runtime-resolved `factory()` carries a single, documented `@phpstan-ignore` (HasFactory's `factory()` isn't visible on a `class-string<Model>`).
- **`Engagement::newFactory()` added** so the factory resolves regardless of the consuming app's namespace.
- **Arch guard** (`tests/Arch.php`): shipped factories may not depend on the `Cjmellor\Engageify\Tests` namespace — this is the RED that drove the change.
- **Functional tests** covering that `Engagement::factory()` builds a persistable engagement from the configured model.

## Verification

`composer test` green: Pint ✓ · Rector ✓ · larastan (L5) "No errors" ✓ · type-coverage 100% ✓ · 104 passed / 195 assertions · code coverage 100%.
