### PR TITLE
[2.x] Document the v1 to v2 recount backfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased (v2)
+
+### Breaking changes
+
+- **Counts and scores are now read from a denormalised `engagement_counters` table** instead of being counted from the `engagements` table on the fly. Existing v1 installs **must run `php artisan engageify:recount` once** (after publishing and running the new migrations) to backfill the counters — until then, counts, scores, and ranking queries read as `0` for pre-existing engagements. See [Upgrading from v1](README.md#upgrading-from-v1) and [`UPGRADING.md`](UPGRADING.md).
+- **The in-memory cache layer has been removed.** The `allow_caching` and `cache_duration` config keys no longer exist; counts are kept fresh inside the same transaction as each engage/disengage, so there is nothing to invalidate.
+
 ## v0.0.1 - 2023-10-08
 
 ### What's Changed

--- a/README.md
+++ b/README.md
@@ -24,6 +24,29 @@ php artisan vendor:publish --tag="engageify-config"
 
 The published config file allows you to customize table names, model relationships, and more.
 
+## Upgrading from v1
+
+v2 changes how engagement counts are stored and read. **If you are upgrading an existing v1 install, run these steps once — otherwise your counts and scores will read as `0`.**
+
+1. **Publish and run the new migrations.** v2 adds a `value` column to `engagements` and introduces the denormalised `engagement_counters` table (plus the opt-in `view_buckets` table):
+
+   ```bash
+   php artisan vendor:publish --tag="engageify-migrations"
+   php artisan migrate
+   ```
+
+2. **Backfill the counters (required).** Counts and scores are now read from `engagement_counters`, which starts **empty**. Rebuild it from your existing `engagements` rows:
+
+   ```bash
+   php artisan engageify:recount
+   ```
+
+   Until you run this, every count, score, and ranking query returns **`0`** for pre-existing engagements. The engagement rows themselves are untouched — only the counter table needs building.
+
+> **Heads-up:** the in-memory cache layer from v1 has been removed. Counts are kept in step inside the same database transaction as every engage/disengage, so they are always fresh — the `allow_caching` / `cache_duration` config keys no longer exist, and there is nothing to invalidate.
+
+See [`UPGRADING.md`](UPGRADING.md) for the full checklist.
+
 ## Usage
 
 For Models you wish to have engagement features (likes/upvotes), use the Engageable trait.
@@ -263,7 +286,7 @@ $post->downvotes();
 
 Counts are read from a denormalised `engagement_counters` table that is kept in step **inside the same database transaction** as every engage/disengage/flip — so they are always fresh and O(1) to read (no cache to invalidate, and no stale-count-after-unlike bug).
 
-> The counters are maintained automatically. If you ever write engagement rows directly (bypassing the trait), rebuild them with `php artisan engageify:recount`.
+> The counters are maintained automatically. Run `php artisan engageify:recount` to (re)build them from the `engagements` table — this is **required once when [upgrading from v1](#upgrading-from-v1)** (counters start empty), and also whenever you write engagement rows directly, bypassing the trait.
 
 ### Ranking
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,46 @@
+# Upgrading
+
+## From v1 to v2
+
+v2 reworks how engagement counts are stored and read, and removes the cache
+layer. Follow these steps once when upgrading an existing v1 installation.
+
+### 1. Update the dependency
+
+```bash
+composer require cjmellor/engageify:^2.0
+```
+
+### 2. Publish and run the new migrations
+
+v2 adds a `value` column to the `engagements` table and introduces the
+denormalised `engagement_counters` table (plus the opt-in `view_buckets` table
+that powers time-windowed views):
+
+```bash
+php artisan vendor:publish --tag="engageify-migrations"
+php artisan migrate
+```
+
+### 3. Backfill the counters (required)
+
+Counts and scores are now read from `engagement_counters`, which starts empty.
+Rebuild it from your existing `engagements` rows:
+
+```bash
+php artisan engageify:recount
+```
+
+**Until you run this, all counts, scores, and ranking queries return `0` for
+pre-existing engagements.** The engagement rows themselves are untouched — only
+the counter table needs building.
+
+### Notes
+
+- **The cache layer has been removed.** The `allow_caching` and `cache_duration`
+  config keys no longer exist. Counts are maintained inside the same database
+  transaction as each engage/disengage, so they are always fresh — there is
+  nothing to invalidate.
+- If you keep a published config file, re-publish it
+  (`php artisan vendor:publish --tag="engageify-config"`) to pick up the new
+  `views` and `impressions` sections.


### PR DESCRIPTION
Closes #49.

## What & why

In v2, counts/scores read from the denormalised `engagement_counters` table, which starts **empty**. A v1 install upgrading to v2 keeps all its `engagements` rows but reads **0** for every count, score, and ranking query until the counters are backfilled with `engageify:recount`. The previous docs only mentioned the `value` migration and framed `recount` as a bypass edge-case — so an upgrader had no clear signal. This documents the mandatory backfill where upgraders will look.

## Changes

- **README** — new `## Upgrading from v1` section (publish migrations → `migrate` → `engageify:recount`, with the "reads 0 until you run it" warning and the cache-removal note). The existing recount note now cross-links it.
- **CHANGELOG** — `## Unreleased (v2)` entry recording the read-path change and cache-layer removal as breaking changes.
- **UPGRADING.md** — populated (was empty) with the full v1→v2 checklist. (It's `export-ignore`d from the distributed package, so the same guidance also lives in the README/CHANGELOG that consumers receive.)

Docs-only; no code touched. `composer test` green (102 passed, 100% coverage both kinds, Pint/Rector/larastan clean).
