### PR TITLE
[2.x] Give impressions their own dedup cooldown

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ A *view* is server-detectable; an *impression* (was the element actually on scre
 </article>
 ```
 
-A browser posts that token to the impression endpoint (default `POST /engageify/impressions`), which **verifies the signature** before counting — so only server-rendered, unexpired elements can report an impression. It's layered with the same fingerprint dedup as views and is route-throttled. Forged, tampered, or expired tokens are rejected without counting. Impressions accumulate on the same count-only counter (no per-impression rows).
+A browser posts that token to the impression endpoint (default `POST /engageify/impressions`), which **verifies the signature** before counting — so only server-rendered, unexpired elements can report an impression. It's layered with the same fingerprint dedup as views — on its own `engageify.impressions.cooldown` window — and is route-throttled. Forged, tampered, or expired tokens are rejected without counting. Impressions accumulate on the same count-only counter (no per-impression rows).
 
 #### Enabling the browser tracker
 

--- a/config/engageify.php
+++ b/config/engageify.php
@@ -88,6 +88,13 @@ return [
         'token_ttl' => env(key: 'ENGAGEIFY_IMPRESSION_TOKEN_TTL', default: 86400),
 
         /*
+        | How long (in seconds) a fingerprint is de-duplicated for — repeat
+        | impressions of the same element by the same viewer inside this window
+        | are not counted. Independent of the `views.cooldown` above.
+        */
+        'cooldown' => env(key: 'ENGAGEIFY_IMPRESSION_COOLDOWN', default: 3600),
+
+        /*
         | Inject the impression-tracking script into HTML responses. Off by
         | default — rewriting every HTML response must be a deliberate switch.
         | `threshold` is the fraction of the element that must be visible and

--- a/src/Support/ImpressionRecorder.php
+++ b/src/Support/ImpressionRecorder.php
@@ -21,7 +21,7 @@ class ImpressionRecorder
 
         $key = 'impression:'.$fingerprint.':'.$morphType.':'.$morphId;
 
-        if (! Cache::add(key: $key, value: true, ttl: (int) config(key: 'engageify.views.cooldown'))) {
+        if (! Cache::add(key: $key, value: true, ttl: (int) config(key: 'engageify.impressions.cooldown'))) {
             return;
         }
 

--- a/tests/Feature/ImpressionCooldownTest.php
+++ b/tests/Feature/ImpressionCooldownTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Cjmellor\Engageify\Models\EngagementCounter;
+use Cjmellor\Engageify\Support\ImpressionRecorder;
+use Cjmellor\Engageify\Tests\Fixtures\User;
+
+function recordedImpressions(User $model): int
+{
+    return (int) EngagementCounter::query()
+        ->where('engagementable_type', $model->getMorphClass())
+        ->where('engagementable_id', $model->getKey())
+        ->where('type', ImpressionRecorder::TYPE)
+        ->sum('count');
+}
+
+it('dedupes impressions on the impressions cooldown, independent of the views cooldown', function (): void {
+    config()->set('engageify.users.model', User::class);
+    config()->set('engageify.views.cooldown', 0);
+    config()->set('engageify.impressions.cooldown', 3600);
+    $model = User::factory()->createOne();
+
+    ImpressionRecorder::record($model->getMorphClass(), $model->getKey());
+    ImpressionRecorder::record($model->getMorphClass(), $model->getKey());
+
+    expect(recordedImpressions($model))->toBe(1);
+});


### PR DESCRIPTION
Closes #51.

## What & why

Impression dedup read `engageify.views.cooldown` — the **views** subsystem's key. Impressions and views are separate subsystems, so tuning the view window silently changed how long impressions were de-duplicated, and there was no way to set an impression-specific window (e.g. setting `views.cooldown` to `0` even broke impression counting entirely).

## Changes

- **New `engageify.impressions.cooldown`** config key (default `3600`s, env `ENGAGEIFY_IMPRESSION_COOLDOWN`) with an explanatory comment in the published config.
- **`ImpressionRecorder`** now reads that key instead of `views.cooldown`.
- README note clarifies impressions dedup on their own window.

## Test

RED→GREEN: with `views.cooldown = 0` and `impressions.cooldown = 3600`, two records of the same fingerprint count exactly once — proving impression dedup is decoupled from the views cooldown (old code miscounted).

`composer test` green: Pint ✓ · Rector ✓ · larastan ✓ · type-coverage 100% · 103 passed · coverage 100%.
