### PR TITLE
ci: Pin GitHub Actions to commit SHAs (unblocks Dependabot CI on 1.x)

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3.1.0
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/run-linter.yml
+++ b/.github/workflows/run-linter.yml
@@ -9,12 +9,12 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Lint with Pint
-        uses: aglipanci/laravel-pint-action@2.6
+        uses: aglipanci/laravel-pint-action@36de00d5f5a8a4e12d443e01671daa12a18f4c79 # 2.6
 
       - name: Commit linted files
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7
         with:
           commit_message: "fix: Files linted with Pint"

--- a/.github/workflows/run-pest.yml
+++ b/.github/workflows/run-pest.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
         with:
           php-version: ${{ matrix.php }}
           tools: composer:v2

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -13,18 +13,18 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: main
 
       - name: Update CHANGELOG
-        uses: stefanzweifel/changelog-updater-action@v1
+        uses: stefanzweifel/changelog-updater-action@a938690fad7edf25368f37e43a1ed1b34303eb36 # v1
         with:
           latest-version: ${{ github.event.release.name }}
           release-notes: ${{ github.event.release.body }}
 
       - name: Commit updated CHANGELOG
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7
         with:
           branch: main
           commit_message: Update CHANGELOG


### PR DESCRIPTION
## Why

This repository enforces "all actions must be pinned to a full-length commit SHA". The `1.x` workflows still referenced version tags (`actions/checkout@v6`, `aglipanci/laravel-pint-action@2.6`, `stefanzweifel/git-auto-commit-action@v7`, etc.), so **every CI check failed at setup for any PR against `1.x`** — including the open Dependabot security PRs (#26 symfony/yaml, #27 symfony/polyfill-intl-idn), which is why they're stuck red and unmergeable.

## What

Pin every action in the `1.x` workflows to the commit SHA of the **same tag it already used** (behaviour-preserving — no version changes):

| Action | Tag | Pinned SHA |
|---|---|---|
| actions/checkout | v6 | `de0fac2…ce83dd` |
| aglipanci/laravel-pint-action | 2.6 | `36de00d…18f4c79` |
| stefanzweifel/git-auto-commit-action | v7 | `04702ed…93fcb9` |
| shivammathur/setup-php | v2 | `7c071df…fcadbc` |
| stefanzweifel/changelog-updater-action | v1 | `a938690…03eb36` |
| dependabot/fetch-metadata | v3.1.0 | `25dd0e3…efef98` |

## After this merges

CI can run on `1.x` PRs again. Then `@dependabot rebase` on #26 and #27 will turn them green so they can be merged — resolving the two `symfony/*` low-severity alerts. The HIGH `phpunit/phpunit` alert (no Dependabot PR exists) will be addressed in a follow-up bump to ≥ 10.5.62.
