### PR TITLE
ci: track Composer dependencies with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,16 @@
 version: 2
 updates:
 
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## What

Adds a `composer` ecosystem entry to `.github/dependabot.yml` (on `1.x`, the default branch Dependabot reads its config from).

## Why

The config only watched `github-actions`, so PHP dependency and **security** updates were never opened automatically — this is why the recent phpunit/symfony/polyfill security alerts had no Dependabot PRs and had to be bumped by hand (#64), and why the stale action-update PRs (#26/#27) couldn't be rebased.

## Details

- Weekly schedule, `dependencies` label (mirrors the existing github-actions entry).
- `dev-dependencies` group bundles dev-tool bumps (pest, larastan, pint, rector) into one PR to reduce noise; runtime deps and security updates still open individually.

Config-only — no code or lockfile changes. Needs a non-pusher/bypass merge like #63/#64 (same `1.x` ruleset).