### PR TITLE
[2.x] ci: track Composer dependencies with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,16 @@
 version: 2
 updates:
 
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Mirrors #65 onto `main` so the `composer` Dependabot entry carries into the future `2.x` branch.

Dependabot reads config from the default branch (`1.x`), so on `main` this is inert until `2.x` becomes default — it just keeps the v2 trunk in sync. See #65 for rationale.

Config-only — no code or lockfile changes.