### PR TITLE
[2.x] Make withUserEngagement's returned value deterministic

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,8 @@ $feed = Post::query()->withUserEngagement(EngagementTypes::Like)->get();
 $feed->first()->is_engaged; // true/false — no extra query per row
 ```
 
+If more than one engagement row exists for the same user, target and Verb (e.g. seeded or imported data), the attached `engagement_value` is taken from the **most recent** engagement, so the value is deterministic across database engines.
+
 #### Fetch Users' Who Engaged
 
 Instead of just fetching the amount of engagements, you can fetch the Users who engaged.

--- a/src/Concerns/HasEngagements.php
+++ b/src/Concerns/HasEngagements.php
@@ -386,7 +386,7 @@ trait HasEngagements
 
         if ($type instanceof Rateable) {
             $query
-                ->addSelect(['engagement_value' => $this->userEngagementSubquery(model: $model, type: $type, userKey: $userKey)->select('value')->limit(1)])
+                ->addSelect(['engagement_value' => $this->userEngagementSubquery(model: $model, type: $type, userKey: $userKey)->select('value')->orderByDesc('id')->limit(1)])
                 ->withCasts(['engagement_value' => 'decimal:2']);
         }
 

--- a/tests/Concerns/EngagesWithTest.php
+++ b/tests/Concerns/EngagesWithTest.php
@@ -96,3 +96,22 @@ test('withUserEngagement attaches the typed value for a Rateable Verb', function
     expect($row->is_engaged)->toBeTrue()
         ->and((float) $row->engagement_value)->toBe(4.0);
 });
+
+test('withUserEngagement attaches the most recent value when several rated rows exist for the actor', function (): void {
+    config(['engageify.types' => Rating::class]);
+
+    $this->target->engagements()->createMany([
+        ['user_id' => $this->actor->id, 'type' => Rating::Stars, 'value' => 2],
+        ['user_id' => $this->actor->id, 'type' => Rating::Stars, 'value' => 5],
+    ]);
+
+    $queries = 0;
+    DB::listen(function () use (&$queries): void {
+        $queries++;
+    });
+
+    $row = User::query()->whereKey($this->target->id)->withUserEngagement(Rating::Stars)->first();
+
+    expect($queries)->toBe(1)
+        ->and((float) $row->engagement_value)->toBe(5.0);
+});


### PR DESCRIPTION
Closes #56.

## Problem

The actor-side `withUserEngagement` scope attaches each row's `engagement_value` (for `Rateable` Verbs) via a correlated subquery that selected a single `value` with **no ordering**. When more than one engagement row exists for the same user/target/Verb — seeded or imported data, a custom `Rateable` enum, or future multi-row paths — the subquery returns an indeterminate row, so the "your rating" shown in a feed was non-deterministic across database engines.

(Note: the current `rate()` path upserts a single row per user/target/type, so today's public API can't accumulate multiple rated rows — this hardens the read side against any multi-row storage state.)

## Fix

- Order the value subquery by **most recent** (highest primary key) → deterministic winner.
- Documented the rule in the README feed-state section.

## Tests

- New test sets up a multi-row state for one actor/target/Verb and asserts the most-recent value is attached **in a single query** (N+1-free behaviour preserved).
- Full suite green: Pint · Rector · larastan · type 100% · 103 tests · coverage 100%.

## Acceptance criteria
- [x] Value attached by `withUserEngagement` is deterministic with multiple engagements.
- [x] The chosen rule (most recent) is documented.
- [x] A test with multiple engagements asserts the deterministic result.
- [x] The N+1-free single-query behaviour is preserved.