### PR TITLE
[2.x] Fix views windowing: viewsInLast off-by-one + validate period

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,8 @@ $thread->viewsInLast(7);                            // views in the last 7 days
 Thread::query()->orderByMostViewed('week')->get();  // most viewed this week
 ```
 
+`viewsInLast($days)` counts exactly `$days` daily buckets **ending today** — `viewsInLast(7)` is today plus the previous six days, not eight. `orderByMostViewed($period)` ranks by the same inclusive window; `$period` must be one of `day`, `week`, `month`, or `year` (mapped to 1 / 7 / 30 / 365 days), and any other value throws an `InvalidViewPeriodException`. Called with no argument it ranks by the lifetime total.
+
 > **Buckets can't be backfilled.** While `buckets` is off, only the lifetime total exists — there's no per-day history to reconstruct. If you might ever want windows or trending, enable buckets from day one.
 
 ### Impressions (viewport)

--- a/src/Concerns/HasViews.php
+++ b/src/Concerns/HasViews.php
@@ -4,13 +4,25 @@ declare(strict_types=1);
 
 namespace Cjmellor\Engageify\Concerns;
 
+use Cjmellor\Engageify\Exceptions\InvalidViewPeriodException;
 use Cjmellor\Engageify\Models\EngagementCounter;
 use Cjmellor\Engageify\Models\ViewBucket;
 use Cjmellor\Engageify\Support\ViewRecorder;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Carbon;
 
 trait HasViews
 {
+    /**
+     * @var array<string, int>
+     */
+    protected const array VIEW_WINDOW_DAYS = [
+        'day' => 1,
+        'week' => 7,
+        'month' => 30,
+        'year' => 365,
+    ];
+
     public function recordView(): void
     {
         ViewRecorder::record(viewable: $this);
@@ -30,7 +42,7 @@ trait HasViews
         return (int) ViewBucket::query()
             ->where('viewable_type', $this->getMorphClass())
             ->where('viewable_id', $this->getKey())
-            ->where('date', '>=', today()->subDays($days))
+            ->where('date', '>=', $this->viewWindowFloor($days))
             ->sum(column: 'count');
     }
 
@@ -63,7 +75,7 @@ trait HasViews
                 ViewBucket::query()
                     ->selectRaw('viewable_id, sum(count) as views')
                     ->where('viewable_type', $model->getMorphClass())
-                    ->where('date', '>=', today()->sub("1 {$period}"))
+                    ->where('date', '>=', $this->viewWindowFloor($this->periodToDays($period)))
                     ->groupBy('viewable_id'),
                 'view_window',
                 'view_window.viewable_id',
@@ -72,5 +84,16 @@ trait HasViews
             )
             ->orderBy('view_window.views', $direction)
             ->select("{$model->getTable()}.*");
+    }
+
+    protected function viewWindowFloor(int $days): Carbon
+    {
+        return today()->subDays($days - 1);
+    }
+
+    protected function periodToDays(string $period): int
+    {
+        return self::VIEW_WINDOW_DAYS[$period]
+            ?? throw InvalidViewPeriodException::unsupported($period, array_keys(self::VIEW_WINDOW_DAYS));
     }
 }

--- a/src/Exceptions/InvalidViewPeriodException.php
+++ b/src/Exceptions/InvalidViewPeriodException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cjmellor\Engageify\Exceptions;
+
+use Exception;
+
+class InvalidViewPeriodException extends Exception
+{
+    /**
+     * @param  array<int, string>  $allowed
+     */
+    public static function unsupported(string $period, array $allowed): self
+    {
+        return new self(message: "The view period [{$period}] is not supported. Allowed periods: ".implode(', ', $allowed).'.');
+    }
+}

--- a/tests/Concerns/HasViewsTest.php
+++ b/tests/Concerns/HasViewsTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Cjmellor\Engageify\Exceptions\InvalidViewPeriodException;
 use Cjmellor\Engageify\Models\Engagement;
 use Cjmellor\Engageify\Models\ViewBucket;
 use Cjmellor\Engageify\Tests\Fixtures\User;
@@ -67,6 +68,26 @@ test('with buckets on daily rows are written and viewsInLast works', function ()
     expect($post->viewsInLast(7))->toBe(1);
 });
 
+test('viewsInLast counts exactly N daily buckets ending today', function (): void {
+    $post = User::factory()->createOne();
+
+    ViewBucket::query()->create([
+        'viewable_type' => $post->getMorphClass(),
+        'viewable_id' => $post->id,
+        'date' => today(),
+        'count' => 1,
+    ]);
+
+    ViewBucket::query()->create([
+        'viewable_type' => $post->getMorphClass(),
+        'viewable_id' => $post->id,
+        'date' => today()->subDays(7),
+        'count' => 10,
+    ]);
+
+    expect($post->viewsInLast(7))->toBe(1);
+});
+
 test('orderByMostViewed ranks by the lifetime total', function (): void {
     $popular = User::factory()->createOne();
     $quiet = User::factory()->createOne();
@@ -82,6 +103,33 @@ test('orderByMostViewed ranks by the lifetime total', function (): void {
     $ordered = User::query()->whereIn('id', [$popular->id, $quiet->id])->orderByMostViewed()->pluck('id');
 
     expect($ordered->all())->toBe([$popular->id, $quiet->id]);
+});
+
+test('orderByMostViewed rejects a period outside the allowed set', function (): void {
+    User::query()->orderByMostViewed('fortnight');
+})->throws(InvalidViewPeriodException::class);
+
+test('orderByMostViewed window excludes buckets on the far edge of the period', function (): void {
+    $recent = User::factory()->createOne();
+    $edge = User::factory()->createOne();
+
+    ViewBucket::query()->create([
+        'viewable_type' => $recent->getMorphClass(),
+        'viewable_id' => $recent->id,
+        'date' => today(),
+        'count' => 1,
+    ]);
+
+    ViewBucket::query()->create([
+        'viewable_type' => $edge->getMorphClass(),
+        'viewable_id' => $edge->id,
+        'date' => today()->subDays(7),
+        'count' => 100,
+    ]);
+
+    $ordered = User::query()->whereIn('id', [$recent->id, $edge->id])->orderByMostViewed('week')->pluck('id');
+
+    expect($ordered->all())->toBe([$recent->id, $edge->id]);
 });
 
 test('orderByMostViewed with a period ranks by views within the window only', function (): void {


### PR DESCRIPTION
Closes #57.

## Problem

- `viewsInLast($days)` used an inclusive lower bound of `today - $days`, counting **$days + 1** daily buckets ("last 7 days" actually spanned 8).
- `orderByMostViewed($period)` interpolated the raw `$period` into a relative-date string with **no validation** — an unexpected value silently shifted the window or threw an opaque Carbon error — and it used a different windowing idiom than `viewsInLast`.

## Fix

- `viewsInLast(N)` now counts **exactly N** daily buckets ending today (today inclusive). Documented in the README.
- `orderByMostViewed($period)` validates `$period` against an allowlist (`day`/`week`/`month`/`year` → 1/7/30/365 days) and throws a clear `InvalidViewPeriodException` otherwise.
- Both paths now share a single inclusive-window helper, so the two idioms are unified.

## Tests
- Boundary test: a bucket dated exactly 7 days ago is excluded from `viewsInLast(7)`.
- Boundary test on the ordering path: the same far-edge bucket is excluded from the `'week'` window.
- Invalid-period test asserts `InvalidViewPeriodException`.
- Full suite green: Pint · Rector · larastan · type 100% · 109 tests · coverage 100%.

## Acceptance criteria
- [x] `viewsInLast(N)` counts exactly N days (inclusive of today, documented).
- [x] `orderByMostViewed` accepts only validated periods and fails clearly.
- [x] The two windowing code paths use a consistent approach.
- [x] Tests cover the boundary (off-by-one) and an invalid period.