### PR TITLE
[2.x] Wrap view counter + bucket writes in one transaction

### DIFF
--- a/src/Support/ViewRecorder.php
+++ b/src/Support/ViewRecorder.php
@@ -8,6 +8,8 @@ use Cjmellor\Engageify\Models\EngagementCounter;
 use Cjmellor\Engageify\Models\ViewBucket;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Throwable;
 
 class ViewRecorder
 {
@@ -27,10 +29,18 @@ class ViewRecorder
             return;
         }
 
-        EngagementCounter::record(engageable: $viewable, type: self::TYPE, countDelta: 1, valueDelta: 0);
+        try {
+            DB::transaction(function () use ($viewable): void {
+                EngagementCounter::record(engageable: $viewable, type: self::TYPE, countDelta: 1, valueDelta: 0);
 
-        if (config(key: 'engageify.views.buckets')) {
-            ViewBucket::record(viewable: $viewable, date: today());
+                if (config(key: 'engageify.views.buckets')) {
+                    ViewBucket::record(viewable: $viewable, date: today());
+                }
+            });
+        } catch (Throwable $exception) {
+            Cache::forget(key: $key);
+
+            throw $exception;
         }
     }
 }

--- a/tests/Concerns/HasViewsTest.php
+++ b/tests/Concerns/HasViewsTest.php
@@ -6,6 +6,9 @@ use Cjmellor\Engageify\Exceptions\InvalidViewPeriodException;
 use Cjmellor\Engageify\Models\Engagement;
 use Cjmellor\Engageify\Models\ViewBucket;
 use Cjmellor\Engageify\Tests\Fixtures\User;
+use Illuminate\Database\QueryException;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 test('recordView counts once per fingerprint per cooldown; repeats within the window do not count', function (): void {
     $post = User::factory()->createOne();
@@ -40,6 +43,43 @@ test('recording a view writes no per-view engagement row', function (): void {
     $this->assertDatabaseCount(Engagement::class, 0);
 
     expect($post->viewCount())->toBe(1);
+});
+
+test('recordView is atomic: a failed bucket write rolls back the counter increment', function (): void {
+    config(['engageify.views.buckets' => true]);
+
+    $post = User::factory()->createOne();
+    $this->actingAs($this->user);
+
+    Schema::drop('view_buckets');
+
+    expect(fn () => $post->recordView())->toThrow(QueryException::class);
+
+    expect($post->viewCount())->toBe(0);
+});
+
+test('a failed view write releases the dedup slot so the same view can be retried', function (): void {
+    config(['engageify.views.buckets' => true]);
+
+    $post = User::factory()->createOne();
+    $this->actingAs($this->user);
+
+    Schema::drop('view_buckets');
+    rescue(callback: fn () => $post->recordView(), report: false);
+
+    Schema::create('view_buckets', function (Blueprint $table): void {
+        $table->id();
+        $table->morphs(name: 'viewable');
+        $table->date(column: 'date');
+        $table->unsignedBigInteger(column: 'count')->default(0);
+        $table->timestamps();
+        $table->unique(columns: ['viewable_type', 'viewable_id', 'date']);
+    });
+
+    $post->recordView();
+
+    expect($post->viewCount())->toBe(1);
+    $this->assertDatabaseCount(ViewBucket::class, 1);
 });
 
 test('with buckets off only the lifetime total is kept', function (): void {


### PR DESCRIPTION
Closes #55.

## Problem

Recording a view incremented the lifetime counter and wrote the per-day bucket in **two separate statements with no transaction**, and the dedup cooldown key was claimed **before** the writes. A failure between the two writes left the lifetime total and the per-day bucket permanently disagreeing — and since the cooldown key was already set, the view was never retried.

## Fix

- Wrap both writes in a single `DB::transaction` — they commit or roll back together.
- If the transaction throws, `Cache::forget` the cooldown key (then rethrow) so the same view can be recorded on a later request instead of being silently swallowed for the cooldown window.

The cooldown is still claimed atomically up-front (`Cache::add`) to prevent a concurrent double-count; it's only released when the write actually fails.

## Tests
- Atomicity: with the bucket table made to fail mid-write, the counter increment is rolled back (lifetime total stays consistent, no partial state).
- Dedup release: after a failed write, retrying the same view succeeds (counter **and** bucket both land) — proving the slot wasn't permanently held. Verified RED without the `Cache::forget`.
- Full suite green: Pint · Rector · larastan · type 100% · 111 tests · coverage 100%.

## Acceptance criteria
- [x] Counter and bucket writes occur in one transaction.
- [x] A failure mid-write leaves no partial state.
- [x] Dedup does not permanently swallow a view whose write failed.
- [x] A test proves the two writes are atomic.