### PR TITLE
[2.x] Cache the injected impression script (no per-response disk read)

### DIFF
--- a/src/EngageifyServiceProvider.php
+++ b/src/EngageifyServiceProvider.php
@@ -7,6 +7,7 @@ namespace Cjmellor\Engageify;
 use Cjmellor\Engageify\Commands\RecountCommand;
 use Cjmellor\Engageify\Http\Controllers\ImpressionController;
 use Cjmellor\Engageify\Http\Middleware\InjectImpressionScript;
+use Cjmellor\Engageify\Support\ImpressionScript;
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Route;
@@ -20,6 +21,8 @@ class EngageifyServiceProvider extends ServiceProvider
             path: __DIR__.'/../config/engageify.php',
             key: 'engageify',
         );
+
+        $this->app->singleton(abstract: ImpressionScript::class);
     }
 
     public function boot(): void

--- a/src/Http/Middleware/InjectImpressionScript.php
+++ b/src/Http/Middleware/InjectImpressionScript.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Cjmellor\Engageify\Http\Middleware;
 
+use Cjmellor\Engageify\Support\ImpressionScript;
 use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response as IlluminateResponse;
@@ -11,6 +12,8 @@ use Symfony\Component\HttpFoundation\Response;
 
 class InjectImpressionScript
 {
+    public function __construct(private readonly ImpressionScript $script) {}
+
     /**
      * @param  Closure(Request): Response  $next
      */
@@ -39,19 +42,9 @@ class InjectImpressionScript
 
     private function inject(Response $response, string $content): void
     {
-        $script = str_replace(
-            ['%_ENGAGEIFY_ENDPOINT_%', '%_ENGAGEIFY_THRESHOLD_%', '%_ENGAGEIFY_DWELL_%'],
-            [
-                '/'.ltrim((string) config(key: 'engageify.impressions.endpoint'), '/'),
-                (string) config(key: 'engageify.impressions.threshold'),
-                (string) config(key: 'engageify.impressions.dwell'),
-            ],
-            (string) file_get_contents(__DIR__.'/../../../resources/js/dist/engageify.iife.js'),
-        );
-
         $original = $response instanceof IlluminateResponse ? $response->original : null;
 
-        $response->setContent(str_replace('</body>', '<script>'.$script.'</script></body>', $content));
+        $response->setContent(str_replace('</body>', '<script>'.$this->script->render().'</script></body>', $content));
 
         if ($response instanceof IlluminateResponse) {
             $response->original = $original;

--- a/src/Support/ImpressionScript.php
+++ b/src/Support/ImpressionScript.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cjmellor\Engageify\Support;
+
+use Illuminate\Support\Facades\File;
+
+class ImpressionScript
+{
+    private ?string $raw = null;
+
+    public function render(): string
+    {
+        return str_replace(
+            ['%_ENGAGEIFY_ENDPOINT_%', '%_ENGAGEIFY_THRESHOLD_%', '%_ENGAGEIFY_DWELL_%'],
+            [
+                '/'.ltrim((string) config(key: 'engageify.impressions.endpoint'), '/'),
+                (string) config(key: 'engageify.impressions.threshold'),
+                (string) config(key: 'engageify.impressions.dwell'),
+            ],
+            $this->raw(),
+        );
+    }
+
+    private function path(): string
+    {
+        return __DIR__.'/../../resources/js/dist/engageify.iife.js';
+    }
+
+    private function raw(): string
+    {
+        return $this->raw ??= File::get(path: $this->path());
+    }
+}

--- a/tests/Feature/InjectImpressionScriptTest.php
+++ b/tests/Feature/InjectImpressionScriptTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use Cjmellor\Engageify\Support\ImpressionScript;
+use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Route;
 
 beforeEach(function (): void {
@@ -42,4 +44,25 @@ test('HTML without a closing body tag is left untouched', function (): void {
     $content = (string) $this->get('engageify-test/nobody')->getContent();
 
     expect($content)->not->toContain('<script>');
+});
+
+test('the built script is read from disk only once across renders', function (): void {
+    File::partialMock()->shouldReceive('get')->once()->andReturn('console.log("engageify");');
+
+    $script = resolve(ImpressionScript::class);
+
+    $script->render();
+    $script->render();
+});
+
+test('the injected script reflects the current config after the raw file is memoised', function (): void {
+    config(['engageify.impressions.inject_script' => true]);
+
+    $this->get('engageify-test/html')->assertOk();
+
+    config(['engageify.impressions.endpoint' => 'custom/impressions']);
+
+    $content = (string) $this->get('engageify-test/html')->assertOk()->getContent();
+
+    expect($content)->toContain('/custom/impressions');
 });


### PR DESCRIPTION
Closes #58.

## Problem

When script injection is enabled, the middleware read the built impression script file from disk and ran the placeholder substitutions on **every** HTML response. The file content is identical between requests, so that was repeated disk I/O + string work on the hot path.

## Fix

- Extract an `ImpressionScript` service, bound as a **singleton**, that reads the built file **once per process** (via the `File` facade) and memoises it.
- `render()` still performs the endpoint/threshold/dwell substitution **per response**, so output always reflects current config.
- The middleware depends on the singleton; injected output is unchanged.

## Tests
- Memoisation: `File::get` is called **once** across multiple `render()` calls (verified RED without the memo — Mockery reports >1 call).
- Config still reflected: after the raw file is memoised, changing `impressions.endpoint` is reflected in the next injected response.
- The four existing injection tests still pass (output unchanged).
- Full suite green: Pint · Rector · larastan · type 100% · 113 tests · coverage 100%.

## Acceptance criteria
- [x] Built script read from disk at most once per process.
- [x] Placeholder substitution still reflects current config.
- [x] Injection output unchanged.
- [x] A test asserts the file is not re-read per response (memoised).