### PR TITLE
[2.x] Make the counter hot_score update atomic / lost-update-safe

### DIFF
--- a/src/Models/EngagementCounter.php
+++ b/src/Models/EngagementCounter.php
@@ -8,6 +8,7 @@ use Cjmellor\Engageify\Support\HotScore;
 use DateTimeInterface;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Support\Facades\DB;
 
 /**
  * @property string $type
@@ -21,26 +22,35 @@ class EngagementCounter extends Model
 
     public static function record(Model $engageable, string $type, int $countDelta, int|float $valueDelta): void
     {
-        $counter = static::query()->firstOrCreate([
-            'engagementable_type' => $engageable->getMorphClass(),
-            'engagementable_id' => $engageable->getKey(),
-            'type' => $type,
-        ]);
+        DB::transaction(function () use ($engageable, $type, $countDelta, $valueDelta): void {
+            static::query()->firstOrCreate([
+                'engagementable_type' => $engageable->getMorphClass(),
+                'engagementable_id' => $engageable->getKey(),
+                'type' => $type,
+            ]);
 
-        $counter->increment(column: 'count', amount: $countDelta);
-        $counter->increment(column: 'sum_value', amount: $valueDelta);
+            $counter = static::query()
+                ->where('engagementable_type', $engageable->getMorphClass())
+                ->where('engagementable_id', $engageable->getKey())
+                ->where('type', $type)
+                ->lockForUpdate()
+                ->firstOrFail();
 
-        if ((float) $valueDelta !== 0.0) {
-            $counter->refresh();
+            $counter->increment(column: 'count', amount: $countDelta);
+            $counter->increment(column: 'sum_value', amount: $valueDelta);
 
-            $sum = (float) $counter->sum_value;
-            $createdAt = $engageable->getAttribute($engageable->getCreatedAtColumn() ?? 'created_at');
+            if ((float) $valueDelta !== 0.0) {
+                $counter->refresh();
 
-            $counter->hot_score = $sum !== 0.0 && $createdAt instanceof DateTimeInterface
-                ? HotScore::calculate(score: $sum, createdAt: $createdAt)
-                : 0;
-            $counter->save();
-        }
+                $sum = (float) $counter->sum_value;
+                $createdAt = $engageable->getAttribute($engageable->getCreatedAtColumn() ?? 'created_at');
+
+                $counter->hot_score = $sum !== 0.0 && $createdAt instanceof DateTimeInterface
+                    ? HotScore::calculate(score: $sum, createdAt: $createdAt)
+                    : 0;
+                $counter->save();
+            }
+        });
     }
 
     public static function tally(string $engagementableType, int|string $engagementableId, string $type): void

--- a/tests/Concerns/RankingHotTopTest.php
+++ b/tests/Concerns/RankingHotTopTest.php
@@ -7,6 +7,8 @@ use Cjmellor\Engageify\Models\EngagementCounter;
 use Cjmellor\Engageify\Tests\Fixtures\Enums\Rating;
 use Cjmellor\Engageify\Tests\Fixtures\Enums\Vote;
 use Cjmellor\Engageify\Tests\Fixtures\User;
+use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Support\Facades\DB;
 
 beforeEach(function (): void {
     $this->actingAs($this->user);
@@ -86,6 +88,23 @@ test('orderByBayesian ranks honestly using the global mean, with a configurable 
 
     expect(array_search($sure->id, $ordered, true))
         ->toBeLessThan(array_search($unsure->id, $ordered, true));
+});
+
+test('record updates the counter inside its own transaction so callers need not', function (): void {
+    config(['engageify.types' => Vote::class]);
+
+    $post = User::factory()->createOne();
+
+    EngagementCounter::record(engageable: $post, type: Vote::Up->value, countDelta: 1, valueDelta: 1.0);
+
+    $levels = [];
+    DB::listen(function (QueryExecuted $query) use (&$levels): void {
+        $levels[] = $query->connection->transactionLevel();
+    });
+
+    EngagementCounter::record(engageable: $post, type: Vote::Up->value, countDelta: 1, valueDelta: 1.0);
+
+    expect(max($levels))->toBeGreaterThan(1);
 });
 
 test('the counter columns are exposed for custom ranking scopes', function (): void {


### PR DESCRIPTION
Closes #50.

## Problem

When a value-carrying engagement updated a counter, the new `hot_score` was computed by reading the freshly-incremented `sum_value` back out and writing it in a **separate, unguarded** step — and some callers (the view/impression paths) opened no transaction at all. Under concurrent engagements on the same target, two writers could read the same sum and persist divergent or stale `hot_score` values, so Hot ranking could order by a wrong score until the next write (or a `recount`) repaired it.

## Fix

- `record()` now wraps its whole read-modify-write in its **own** `DB::transaction`.
- It takes a `lockForUpdate` on the counter row before the increments + `hot_score` recompute, serialising concurrent writers to the same target (row lock on MySQL/Postgres; SQLite already serialises writes DB-wide).
- Correctness no longer depends on the caller opening a transaction.

## Tests
- New test proves `record()` runs inside its own transaction (its queries execute at a nested savepoint level above RefreshDatabase's own transaction — verified RED without the wrapper).
- All existing Hot / Top / Bayesian ranking tests still pass — single-writer values unchanged.
- Full suite green: Pint · Rector · larastan · type 100% · 114 tests · coverage 100%.

## Acceptance criteria
- [x] hot_score update cannot lose an update under concurrent writers.
- [x] Correctness does not depend on the caller opening a transaction.
- [x] Hot ranking values unchanged for the single-writer case.
- [x] A test proves the update is self-contained / atomic.