### PR TITLE
[2.x] Protect the counter count from underflow on disengage/flip

### DIFF
--- a/database/migrations/2026_05_31_000001_create_engagement_counters_table.php
+++ b/database/migrations/2026_05_31_000001_create_engagement_counters_table.php
@@ -14,7 +14,7 @@ return new class extends Migration
             $table->id();
             $table->morphs(name: 'engagementable');
             $table->string(column: 'type');
-            $table->unsignedBigInteger(column: 'count')->default(0);
+            $table->bigInteger(column: 'count')->default(0);
             $table->decimal(column: 'sum_value', total: 8, places: 2)->default(0);
             $table->timestamps();
 

--- a/tests/Concerns/EngagementCounterTest.php
+++ b/tests/Concerns/EngagementCounterTest.php
@@ -30,6 +30,18 @@ test('engaging increments the counter and disengaging decrements it — no stale
     ]);
 });
 
+test('a counter decremented below zero is stored without an out-of-range error and recount repairs it', function (): void {
+    config(['engageify.types' => Vote::class]);
+
+    EngagementCounter::record(engageable: $this->user, type: Vote::Up->value, countDelta: -1, valueDelta: -1.0);
+
+    expect(EngagementCounter::query()->where('type', Vote::Up->value)->firstOrFail()->count)->toBe(-1);
+
+    EngagementCounter::rebuild();
+
+    $this->assertDatabaseCount(EngagementCounter::class, 0);
+});
+
 test('a counter belongs to its engageable', function (): void {
     $this->user->like();
 


### PR DESCRIPTION
Closes #52.

## Problem

`engagement_counters.count` was an **unsigned** integer, but the disengage and exclusive-flip paths decrement it. The normal like→unlike path returns cleanly to zero, but any race or recount drift that drives the value below zero raises an **out-of-range error on MySQL/Postgres**. CI runs on SQLite, which silently permits negatives, so this was invisible.

## Fix

- Make `count` a **signed** `bigInteger`, so a decrement past zero stores a transient negative instead of erroring; `recount` repairs it.
- `view_buckets.count` is only ever incremented, so it stays unsigned.

## Migration ordering (per ticket)

This edits the **unreleased** v2 `create_engagement_counters` migration **in place** rather than shipping a separate ALTER migration. All v2 migrations ship together at 2.0, so altering a table created moments earlier in the same batch would be pointless churn for a fresh install. The indexes ticket (#53) likewise edits the create migrations in place; the two touch the same file but are merged sequentially, so there is no ordering conflict.

## Tests
- New regression test drives `count` below zero, asserts it's stored (no error on the configured DB) and that `recount` rebuilds correct state.
- Existing to-zero boundary (like→unlike) and flip-decrement tests still pass.
- Full suite green: Pint · Rector · larastan · type 100% · 115 tests · coverage 100%.

> Note: the unsigned→signed protection itself can't be exercised on SQLite (no unsigned enforcement) — per the ticket's own observation. The migration diff is the fix; the test covers the decrement path + recount.

## Acceptance criteria
- [x] Decrementing a counter can never raise an out-of-range error on MySQL/Postgres (signed column).
- [x] Ships as a migration change; ordering vs the indexes ticket noted above.
- [x] Regression test covers the decrement path and the at-zero boundary.
- [x] recount still rebuilds correct values.