### PR TITLE
[2.x] Add the missing ranking/window indexes (counters + buckets)

### DIFF
--- a/database/migrations/2026_05_31_000001_create_engagement_counters_table.php
+++ b/database/migrations/2026_05_31_000001_create_engagement_counters_table.php
@@ -19,6 +19,7 @@ return new class extends Migration
             $table->timestamps();
 
             $table->unique(columns: ['engagementable_type', 'engagementable_id', 'type']);
+            $table->index(columns: 'type');
         });
 
         Schema::table('engagements', function (Blueprint $table): void {

--- a/database/migrations/2026_05_31_000003_create_view_buckets_table.php
+++ b/database/migrations/2026_05_31_000003_create_view_buckets_table.php
@@ -18,6 +18,7 @@ return new class extends Migration
             $table->timestamps();
 
             $table->unique(columns: ['viewable_type', 'viewable_id', 'date']);
+            $table->index(columns: ['viewable_type', 'date']);
         });
     }
 };

--- a/tests/Feature/SchemaIndexesTest.php
+++ b/tests/Feature/SchemaIndexesTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Schema;
+
+test('the counter table is indexed for type-filtered aggregates', function (): void {
+    $indexes = collect(Schema::getIndexes('engagement_counters'))
+        ->map(fn (array $index): array => $index['columns']);
+
+    expect($indexes->contains(['type']))->toBeTrue();
+});
+
+test('the bucket table is indexed for the viewable-type/date window scan', function (): void {
+    $indexes = collect(Schema::getIndexes('view_buckets'))
+        ->map(fn (array $index): array => $index['columns']);
+
+    expect($indexes->contains(['viewable_type', 'date']))->toBeTrue();
+});


### PR DESCRIPTION
Closes #53.

## Problem

Two read paths scanned unindexed columns and would degrade at scale:

- The **Bayesian global mean** runs aggregate sums over `engagement_counters` filtered by `type` only. The unique index leads with `engagementable_type`, so a type-only filter wasn't served.
- The **most-viewed-in-period** window scans `view_buckets` by `viewable_type` + `date`. The unique index leads with `viewable_type` but has `viewable_id` second, so the (type, date) range wasn't served.

## Fix

- `engagement_counters`: add an index on `type`.
- `view_buckets`: add a composite index on `(viewable_type, date)`.

Purely additive — no behavioural change.

## Migration ordering (per ticket)

Edited the **unreleased** v2 create migrations **in place**, same rationale as the underflow ticket (#52): all v2 migrations ship together at 2.0. #52 (now merged) changed the `count` column in the same create-counters file; this PR was branched off that merge, so the two are sequential with no conflict.

## Tests
- New test introspects the schema and asserts both indexes exist (verified RED before the migration change).
- Full suite green: Pint · Rector · larastan · type 100% · 117 tests · coverage 100%.

## Acceptance criteria
- [x] Counter table has an index supporting type-filtered aggregates.
- [x] Bucket table has a (viewable_type, date) index.
- [x] Added via migration; ordering vs #52 noted above.
- [x] Purely additive — existing tests still pass.