### PR TITLE
[2.x] Stop registering the impression middleware on the global HTTP stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,7 +419,9 @@ ENGAGEIFY_IMPRESSION_INJECT=true
 
 or set `engageify.impressions.inject_script` to `true`. Tune detection with `engageify.impressions.threshold` (0–1) and `dwell` (ms). Mark elements with `@impression($model)` and they'll be tracked automatically.
 
-(Prefer to wire it up yourself? Leave the middleware off and include `resources/js/dist/engageify.iife.js` however you like.)
+While injection is off, the middleware is **not added to the global HTTP stack at all** — it costs you nothing per request. Enabling it pushes it onto the global stack so every HTML response is rewritten; this is a config-time decision, so toggle the setting and clear your config cache (`php artisan config:clear`) for it to take effect.
+
+(Prefer to wire it up yourself? Leave the setting off and include `resources/js/dist/engageify.iife.js` however you like.)
 
 ## Events
 

--- a/src/EngageifyServiceProvider.php
+++ b/src/EngageifyServiceProvider.php
@@ -35,7 +35,7 @@ class EngageifyServiceProvider extends ServiceProvider
 
         $this->registerImpressionRoute();
 
-        $this->app->make(Kernel::class)->pushMiddleware(InjectImpressionScript::class);
+        $this->registerInjectionMiddleware();
 
         Blade::directive('impression', fn (string $expression): string => "<?php echo \Cjmellor\Engageify\Support\ImpressionToken::attribute({$expression}); ?>");
 
@@ -46,6 +46,13 @@ class EngageifyServiceProvider extends ServiceProvider
         $this->publishesMigrations([
             __DIR__.'/../database/migrations' => database_path(path: 'migrations'),
         ], groups: 'engageify-migrations');
+    }
+
+    public function registerInjectionMiddleware(): void
+    {
+        if (config(key: 'engageify.impressions.inject_script')) {
+            $this->app->make(Kernel::class)->pushMiddleware(InjectImpressionScript::class);
+        }
     }
 
     protected function registerImpressionRoute(): void

--- a/src/Http/Middleware/InjectImpressionScript.php
+++ b/src/Http/Middleware/InjectImpressionScript.php
@@ -21,10 +21,6 @@ class InjectImpressionScript
     {
         $response = $next($request);
 
-        if (! config(key: 'engageify.impressions.inject_script')) {
-            return $response;
-        }
-
         if (! str_contains(strtolower((string) $response->headers->get('Content-Type')), 'text/html')) {
             return $response;
         }

--- a/tests/Feature/InjectImpressionScriptTest.php
+++ b/tests/Feature/InjectImpressionScriptTest.php
@@ -2,18 +2,33 @@
 
 declare(strict_types=1);
 
+use Cjmellor\Engageify\EngageifyServiceProvider;
+use Cjmellor\Engageify\Http\Middleware\InjectImpressionScript;
 use Cjmellor\Engageify\Support\ImpressionScript;
+use Illuminate\Contracts\Http\Kernel;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Response;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Route;
 
 beforeEach(function (): void {
-    Route::get('engageify-test/html', fn (): Illuminate\Contracts\Routing\ResponseFactory|\Illuminate\Http\Response => response('<html><body><p>hi</p></body></html>'));
-    Route::get('engageify-test/json', fn () => response()->json(['ok' => true]));
-    Route::get('engageify-test/nobody', fn (): Illuminate\Contracts\Routing\ResponseFactory|\Illuminate\Http\Response => response('<html>no closing body</html>'));
+    Route::get('engageify-test/html', fn (): Response => response('<html><body><p>hi</p></body></html>'));
+    Route::get('engageify-test/json', fn (): JsonResponse => response()->json(['ok' => true]));
+    Route::get('engageify-test/nobody', fn (): Response => response('<html>no closing body</html>'));
 });
 
-test('the tracking script is injected before </body> when enabled', function (): void {
+test('the injection middleware is off the global stack by default and registered only when enabled', function (): void {
+    expect(resolve(Kernel::class)->hasMiddleware(InjectImpressionScript::class))->toBeFalse();
+
     config(['engageify.impressions.inject_script' => true]);
+    (new EngageifyServiceProvider($this->app))->registerInjectionMiddleware();
+
+    expect(resolve(Kernel::class)->hasMiddleware(InjectImpressionScript::class))->toBeTrue();
+});
+
+test('once enabled, the tracking script is injected before </body> on an HTML response', function (): void {
+    config(['engageify.impressions.inject_script' => true]);
+    (new EngageifyServiceProvider($this->app))->registerInjectionMiddleware();
 
     $content = (string) $this->get('engageify-test/html')->assertOk()->getContent();
 
@@ -24,14 +39,9 @@ test('the tracking script is injected before </body> when enabled', function ():
         ->toContain('</script></body>');
 });
 
-test('the script is not injected when disabled by default', function (): void {
-    $content = (string) $this->get('engageify-test/html')->getContent();
-
-    expect($content)->not->toContain('<script>');
-});
-
-test('non-HTML responses are left untouched', function (): void {
+test('a non-HTML response is left untouched', function (): void {
     config(['engageify.impressions.inject_script' => true]);
+    (new EngageifyServiceProvider($this->app))->registerInjectionMiddleware();
 
     $content = (string) $this->get('engageify-test/json')->getContent();
 
@@ -40,10 +50,23 @@ test('non-HTML responses are left untouched', function (): void {
 
 test('HTML without a closing body tag is left untouched', function (): void {
     config(['engageify.impressions.inject_script' => true]);
+    (new EngageifyServiceProvider($this->app))->registerInjectionMiddleware();
 
     $content = (string) $this->get('engageify-test/nobody')->getContent();
 
     expect($content)->not->toContain('<script>');
+});
+
+test('the injected script reflects the current endpoint config', function (): void {
+    config([
+        'engageify.impressions.inject_script' => true,
+        'engageify.impressions.endpoint' => 'custom/impressions',
+    ]);
+    (new EngageifyServiceProvider($this->app))->registerInjectionMiddleware();
+
+    $content = (string) $this->get('engageify-test/html')->assertOk()->getContent();
+
+    expect($content)->toContain('/custom/impressions');
 });
 
 test('the built script is read from disk only once across renders', function (): void {
@@ -53,16 +76,4 @@ test('the built script is read from disk only once across renders', function ():
 
     $script->render();
     $script->render();
-});
-
-test('the injected script reflects the current config after the raw file is memoised', function (): void {
-    config(['engageify.impressions.inject_script' => true]);
-
-    $this->get('engageify-test/html')->assertOk();
-
-    config(['engageify.impressions.endpoint' => 'custom/impressions']);
-
-    $content = (string) $this->get('engageify-test/html')->assertOk()->getContent();
-
-    expect($content)->toContain('/custom/impressions');
 });


### PR DESCRIPTION
Closes #48.

## Decision

Per maintainer review, implemented the **conditional global** approach (option 1 of the three candidates): the middleware is pushed onto the global stack **only when `inject_script` is enabled**. This keeps Engageify's zero-config UX (`ENGAGEIFY_IMPRESSION_INJECT=true` and it just works) while ensuring consumers who don't use injection pay nothing.

## Changes

- Provider registers the middleware only when `engageify.impressions.inject_script` is true. Extracted to a public `registerInjectionMiddleware()` so both branches of the decision are covered by tests.
- Removed the middleware's own redundant `inject_script` guard — registration is now the single gate (so when present, it always processes; when disabled, it isn't on the stack at all).
- README documents the registration model (off the global stack until enabled; toggling is a config-time decision — clear the config cache).

## Tests
- New registration test: middleware is **absent** from the global stack by default and **present** after enabling — covering both branches.
- The injection-behaviour tests register the middleware then assert injection on HTML / skip on non-HTML / skip on no-`</body>` / reflect the endpoint config.
- Full suite green: Pint · Rector · larastan · type 100% · 117 tests · coverage 100%.

## Acceptance criteria
- [x] With `inject_script` disabled, the middleware is not on the global stack (zero per-response work).
- [x] Enabling injection is a documented, deliberate opt-in.
- [x] Existing injection behaviour still works once enabled.
- [x] Tests cover both the disabled (absent) and enabled (injects) paths.
- [x] README describes the chosen registration model.