### PR TITLE
ci: make the Tests badge report status on main

### DIFF
--- a/.github/workflows/run-pest.yml
+++ b/.github/workflows/run-pest.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
       - "1.x"
-  pull_request
+  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/run-pest.yml
+++ b/.github/workflows/run-pest.yml
@@ -1,5 +1,10 @@
 name: "Run Pest"
-on: pull_request
+on:
+  push:
+    branches:
+      - main
+      - "1.x"
+  pull_request
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/cjmellor/engageify?color=rgb%2856%20189%20248%29&label=release&style=for-the-badge)](https://packagist.org/packages/cjmellor/engageify)
-[![GitHub Tests Action Status](https://img.shields.io/github/actions/workflow/status/cjmellor/engageify/run-pest.yml?branch=main&label=tests&style=for-the-badge&color=rgb%28134%20239%20128%29)](https://github.com/cjmellor/engageify/actions?query=workflow%3Arun-tests+branch%3Amain)
+[![GitHub Tests Action Status](https://img.shields.io/github/actions/workflow/status/cjmellor/engageify/run-pest.yml?branch=main&label=tests&style=for-the-badge&color=rgb%28134%20239%20128%29)](https://github.com/cjmellor/engageify/actions/workflows/run-pest.yml?query=branch%3Amain)
 [![Total Downloads](https://img.shields.io/packagist/dt/cjmellor/engageify.svg?color=rgb%28249%20115%2022%29&style=for-the-badge)](https://packagist.org/packages/cjmellor/engageify)
 ![Packagist PHP Version](https://img.shields.io/packagist/dependency-v/cjmellor/engageify/php?color=rgb%28165%20180%20252%29&logo=php&logoColor=rgb%28165%20180%20252%29&style=for-the-badge)
 ![Laravel Version](https://img.shields.io/badge/laravel-^10-rgb(235%2068%2050)?style=for-the-badge&logo=laravel)


### PR DESCRIPTION
## What

The README Tests badge showed **"No status"**.

`run-pest.yml` only triggered `on: pull_request`, so every run was attributed to the PR's source branch — never to the `main` branch tip. The shields.io badge queries `?branch=main`, found no matching run, and rendered *No status*.

## Fix

- Trigger **Run Pest** on `push` to `main` and `1.x` as well as `pull_request`. The branch tip now gets a recorded run the badge can read. (Merging this PR is itself the first push to `main`, so the badge populates immediately.)
- Point the badge's click-through link at the real `run-pest.yml` workflow (it referenced a non-existent `run-tests` workflow name).

## Notes

No test or source changes — CI trigger + README link only.