### PR TITLE
[2.x] Register multiple verb enums in engageify.types (#77)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,30 @@ $post->engagementCount(Reaction::Bookmark); // 1
 $post->disengage(Reaction::Bookmark);
 ```
 
-Passing a Verb that does not belong to the configured enum throws an `UnknownEngagementType` exception.
+Passing a Verb that belongs to no registered enum throws an `UnknownEngagementType` exception.
+
+#### Mixing several Verb enums
+
+A single enum is all-rateable, all-exclusive, or all-plain (PHP enums implement interfaces at the enum level). To use **different kinds of Verb together** — say star ratings, up/down votes and plain likes in the same app — register every Verb enum as an array:
+
+```php
+// config/engageify.php
+'types' => [
+    App\Enums\Stars::class,   // Rateable
+    App\Enums\Vote::class,    // Exclusive + HasWeight
+    App\Enums\Reaction::class, // plain (like, bookmark…)
+],
+```
+
+Then engage any of them on the same model, with no per-call configuration:
+
+```php
+$film->engage(Stars::Rating, 4);
+$film->engage(Vote::Up);
+$film->like();
+```
+
+`engage()`, the built-in helpers (`like()`, `upvote()`, …), the stored-type cast and exclusive-group lookups all resolve a Verb from whichever registered enum defines it. A single enum (the default) keeps working unchanged. The one rule: registered enums must use **unique backed values** — a collision is rejected at boot with an `AmbiguousEngagementType` exception.
 
 ### Weighted Verbs & Engagement Values
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,9 @@ $film->engage(Vote::Up);
 $film->like();
 ```
 
-`engage()`, the built-in helpers (`like()`, `upvote()`, …), the stored-type cast and exclusive-group lookups all resolve a Verb from whichever registered enum defines it. A single enum (the default) keeps working unchanged. The one rule: registered enums must use **unique backed values** — a collision is rejected at boot with an `AmbiguousEngagementType` exception.
+`engage()`, the built-in helpers (`like()`, `upvote()`, …), the stored-type cast and exclusive-group lookups all resolve a Verb from whichever registered enum defines it. A single enum (the default) keeps working unchanged.
+
+The registry is validated **once at boot**: every entry must be a backed enum implementing `EngagementType` (otherwise `InvalidEngagementEnum`), and their values must be **collectively unique** (otherwise `AmbiguousEngagementType`). Because the check runs at boot, swapping `engageify.types` at runtime bypasses it.
 
 ### Weighted Verbs & Engagement Values
 

--- a/config/engageify.php
+++ b/config/engageify.php
@@ -11,7 +11,8 @@ return [
     |
     | The string-backed enum that defines the available engagement Verbs. Ship
     | your own enum implementing Cjmellor\Engageify\Contracts\EngagementType to
-    | extend the vocabulary — no migration required.
+    | extend the vocabulary — no migration required. Pass an array of enums to
+    | mix rateable, exclusive and plain Verbs in one app (values must be unique).
     |
     */
     'types' => EngagementTypes::class,

--- a/src/Casts/EngagementTypeCast.php
+++ b/src/Casts/EngagementTypeCast.php
@@ -26,8 +26,12 @@ class EngagementTypeCast implements CastsAttributes
     /**
      * @param  array<string, mixed>  $attributes
      */
-    public function set(Model $model, string $key, mixed $value, array $attributes): ?string
+    public function set(Model $model, string $key, mixed $value, array $attributes): string
     {
-        return $value instanceof BackedEnum ? (string) $value->value : $value;
+        if (! $value instanceof BackedEnum) {
+            $value = TypeResolver::resolve(value: (string) $value);
+        }
+
+        return (string) $value->value;
     }
 }

--- a/src/Casts/EngagementTypeCast.php
+++ b/src/Casts/EngagementTypeCast.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cjmellor\Engageify\Casts;
+
+use BackedEnum;
+use Cjmellor\Engageify\Contracts\EngagementType;
+use Cjmellor\Engageify\Support\TypeResolver;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @implements CastsAttributes<EngagementType, EngagementType>
+ */
+class EngagementTypeCast implements CastsAttributes
+{
+    /**
+     * @param  array<string, mixed>  $attributes
+     */
+    public function get(Model $model, string $key, mixed $value, array $attributes): ?EngagementType
+    {
+        return $value === null ? null : TypeResolver::resolve(value: (string) $value);
+    }
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     */
+    public function set(Model $model, string $key, mixed $value, array $attributes): ?string
+    {
+        return $value instanceof BackedEnum ? (string) $value->value : $value;
+    }
+}

--- a/src/Concerns/HasEngagements.php
+++ b/src/Concerns/HasEngagements.php
@@ -452,9 +452,8 @@ trait HasEngagements
      */
     protected function exclusiveGroupValues(string $group): array
     {
-        $enum = TypeResolver::enum();
-
-        return collect($enum::cases())
+        return collect(TypeResolver::enums())
+            ->flatMap(fn (string $enum): array => $enum::cases())
             ->filter(fn (EngagementType $case): bool => $case instanceof Exclusive && $case->group() === $group)
             ->map(fn (EngagementType $case): string => $case->value)
             ->values()

--- a/src/EngageifyServiceProvider.php
+++ b/src/EngageifyServiceProvider.php
@@ -8,6 +8,7 @@ use Cjmellor\Engageify\Commands\RecountCommand;
 use Cjmellor\Engageify\Http\Controllers\ImpressionController;
 use Cjmellor\Engageify\Http\Middleware\InjectImpressionScript;
 use Cjmellor\Engageify\Support\ImpressionScript;
+use Cjmellor\Engageify\Support\TypeResolver;
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Route;
@@ -27,6 +28,8 @@ class EngageifyServiceProvider extends ServiceProvider
 
     public function boot(): void
     {
+        TypeResolver::assertUniqueValues();
+
         if ($this->app->runningInConsole()) {
             $this->commands(commands: [
                 RecountCommand::class,

--- a/src/Exceptions/AmbiguousEngagementType.php
+++ b/src/Exceptions/AmbiguousEngagementType.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cjmellor\Engageify\Exceptions;
+
+use Cjmellor\Engageify\Contracts\EngagementType;
+use Exception;
+
+class AmbiguousEngagementType extends Exception
+{
+    /**
+     * @param  list<class-string<EngagementType>>  $enums
+     */
+    public static function value(string $value, array $enums): self
+    {
+        return new self(message: "The engagement value [{$value}] is defined by more than one registered enum [".implode(', ', $enums).']. Registered verb enums must use unique backed values.');
+    }
+}

--- a/src/Exceptions/InvalidEngagementEnum.php
+++ b/src/Exceptions/InvalidEngagementEnum.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cjmellor\Engageify\Exceptions;
+
+use Cjmellor\Engageify\Contracts\EngagementType;
+use Exception;
+
+class InvalidEngagementEnum extends Exception
+{
+    public static function notAnEnum(string $class): self
+    {
+        return new self(message: "The engageify.types entry [{$class}] is not a backed enum implementing ".EngagementType::class.'.');
+    }
+}

--- a/src/Exceptions/UnknownEngagementType.php
+++ b/src/Exceptions/UnknownEngagementType.php
@@ -10,18 +10,18 @@ use Exception;
 class UnknownEngagementType extends Exception
 {
     /**
-     * @param  class-string<EngagementType>  $enum
+     * @param  list<class-string<EngagementType>>  $enums
      */
-    public static function value(string $value, string $enum): self
+    public static function value(string $value, array $enums): self
     {
-        return new self(message: "The configured engagement enum [{$enum}] has no case for value [{$value}].");
+        return new self(message: "No registered engagement enum has a case for value [{$value}]. Registered: [".implode(', ', $enums).'].');
     }
 
     /**
-     * @param  class-string<EngagementType>  $enum
+     * @param  list<class-string<EngagementType>>  $enums
      */
-    public static function instance(EngagementType $type, string $enum): self
+    public static function instance(EngagementType $type, array $enums): self
     {
-        return new self(message: 'The engagement type ['.$type::class.'] does not belong to the configured enum ['.$enum.'].');
+        return new self(message: 'The engagement type ['.$type::class.'] is not a registered verb enum. Registered: ['.implode(', ', $enums).'].');
     }
 }

--- a/src/Models/Engagement.php
+++ b/src/Models/Engagement.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Cjmellor\Engageify\Models;
 
+use Cjmellor\Engageify\Casts\EngagementTypeCast;
 use Cjmellor\Engageify\Contracts\EngagementType;
 use Cjmellor\Engageify\Database\Factories\EngagementFactory;
 use Illuminate\Database\Eloquent\Factories\Factory;
@@ -43,7 +44,7 @@ class Engagement extends Model
     protected function casts(): array
     {
         return [
-            'type' => config(key: 'engageify.types'),
+            'type' => EngagementTypeCast::class,
             'value' => 'decimal:2',
         ];
     }

--- a/src/Support/TypeResolver.php
+++ b/src/Support/TypeResolver.php
@@ -6,6 +6,7 @@ namespace Cjmellor\Engageify\Support;
 
 use Cjmellor\Engageify\Contracts\EngagementType;
 use Cjmellor\Engageify\Exceptions\AmbiguousEngagementType;
+use Cjmellor\Engageify\Exceptions\InvalidEngagementEnum;
 use Cjmellor\Engageify\Exceptions\UnknownEngagementType;
 
 class TypeResolver
@@ -29,6 +30,10 @@ class TypeResolver
         $owner = [];
 
         foreach (self::enums() as $enum) {
+            if (! enum_exists($enum) || ! is_subclass_of($enum, EngagementType::class)) {
+                throw InvalidEngagementEnum::notAnEnum(class: $enum);
+            }
+
             foreach ($enum::cases() as $case) {
                 if (isset($owner[$case->value])) {
                     throw AmbiguousEngagementType::value(value: $case->value, enums: [$owner[$case->value], $enum]);

--- a/src/Support/TypeResolver.php
+++ b/src/Support/TypeResolver.php
@@ -5,40 +5,65 @@ declare(strict_types=1);
 namespace Cjmellor\Engageify\Support;
 
 use Cjmellor\Engageify\Contracts\EngagementType;
+use Cjmellor\Engageify\Exceptions\AmbiguousEngagementType;
 use Cjmellor\Engageify\Exceptions\UnknownEngagementType;
 
 class TypeResolver
 {
     /**
-     * @return class-string<EngagementType>
+     * @return list<class-string<EngagementType>>
      */
-    public static function enum(): string
+    public static function enums(): array
     {
-        /** @var class-string<EngagementType> $enum */
-        $enum = config(key: 'engageify.types');
+        /** @var class-string<EngagementType>|array<class-string<EngagementType>> $types */
+        $types = config(key: 'engageify.types');
 
-        return $enum;
+        return is_array($types) ? array_values($types) : [$types];
     }
 
     /**
-     * @throws UnknownEngagementType when the configured enum has no such case
+     * @throws AmbiguousEngagementType
+     */
+    public static function assertUniqueValues(): void
+    {
+        $owner = [];
+
+        foreach (self::enums() as $enum) {
+            foreach ($enum::cases() as $case) {
+                if (isset($owner[$case->value])) {
+                    throw AmbiguousEngagementType::value(value: $case->value, enums: [$owner[$case->value], $enum]);
+                }
+
+                $owner[$case->value] = $enum;
+            }
+        }
+    }
+
+    /**
+     * @throws UnknownEngagementType when no registered enum has such a case
      */
     public static function resolve(string $value): EngagementType
     {
-        $enum = self::enum();
+        foreach (self::enums() as $enum) {
+            if (($case = $enum::tryFrom($value)) !== null) {
+                return $case;
+            }
+        }
 
-        return $enum::tryFrom($value) ?? throw UnknownEngagementType::value(value: $value, enum: $enum);
+        throw UnknownEngagementType::value(value: $value, enums: self::enums());
     }
 
     /**
-     * @throws UnknownEngagementType when the Verb is a case of a different enum
+     * @throws UnknownEngagementType when the Verb belongs to no registered enum
      */
     public static function ensure(EngagementType $type): EngagementType
     {
-        $enum = self::enum();
+        foreach (self::enums() as $enum) {
+            if ($type instanceof $enum) {
+                return $type;
+            }
+        }
 
-        return $type instanceof $enum
-            ? $type
-            : throw UnknownEngagementType::instance(type: $type, enum: $enum);
+        throw UnknownEngagementType::instance(type: $type, enums: self::enums());
     }
 }

--- a/tests/Concerns/MixedVerbsTest.php
+++ b/tests/Concerns/MixedVerbsTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+use Cjmellor\Engageify\Enums\EngagementTypes;
+use Cjmellor\Engageify\Exceptions\AmbiguousEngagementType;
+use Cjmellor\Engageify\Support\TypeResolver;
+use Cjmellor\Engageify\Tests\Fixtures\Enums\Clap;
+use Cjmellor\Engageify\Tests\Fixtures\Enums\Mood;
+use Cjmellor\Engageify\Tests\Fixtures\Enums\Rating;
+use Cjmellor\Engageify\Tests\Fixtures\Enums\Reaction;
+
+beforeEach(function (): void {
+    $this->actingAs($this->user);
+});
+
+test('a model can engage verbs from several registered enums without swapping config', function (): void {
+    config(['engageify.types' => [Rating::class, Reaction::class]]);
+
+    $this->user->engage(Rating::Stars, 4);
+    $this->user->engage(Reaction::Bookmark);
+
+    expect($this->user->engagementCount(Reaction::Bookmark))->toBe(1)
+        ->and($this->user->averageRating(Rating::Stars))->toBe(4.0);
+});
+
+test('an exclusive verb flips correctly even when its enum is not first in the registry', function (): void {
+    config(['engageify.types' => [Rating::class, Mood::class]]);
+
+    $this->user->engage(Mood::Happy);
+    $this->user->engage(Mood::Sad);
+
+    expect($this->user->engagementCount(Mood::Happy))->toBe(0)
+        ->and($this->user->engagementCount(Mood::Sad))->toBe(1)
+        ->and($this->user->breakdown('mood'))->toMatchArray(['sad' => 1]);
+});
+
+test('registering enums that share a backed value is rejected with a clear error', function (): void {
+    config(['engageify.types' => [Rating::class, Clap::class]]);
+
+    expect(fn () => TypeResolver::assertUniqueValues())
+        ->toThrow(AmbiguousEngagementType::class);
+});
+
+test('stored rows from different registered enums hydrate back to their own cases', function (): void {
+    config(['engageify.types' => [Rating::class, Reaction::class]]);
+
+    $this->user->engage(Rating::Stars, 3);
+    $this->user->engage(Reaction::Bookmark);
+
+    $types = $this->user->engagements()->orderBy('id')->get()->map(fn ($e) => $e->type);
+
+    expect($types[0])->toBe(Rating::Stars)
+        ->and($types[1])->toBe(Reaction::Bookmark);
+});
+
+test('the like() helper resolves its verb from whichever registered enum defines it', function (): void {
+    config(['engageify.types' => [Rating::class, EngagementTypes::class]]);
+
+    $this->user->like();
+
+    expect($this->user->likes())->toBe(1);
+});
+
+test('a single enum (not wrapped in an array) still works', function (): void {
+    config(['engageify.types' => Reaction::class]);
+
+    $this->user->engage(Reaction::Bookmark);
+
+    expect($this->user->engagementCount(Reaction::Bookmark))->toBe(1)
+        ->and($this->user->engagements()->first()->type)->toBe(Reaction::Bookmark);
+});

--- a/tests/Concerns/MixedVerbsTest.php
+++ b/tests/Concerns/MixedVerbsTest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 use Cjmellor\Engageify\Enums\EngagementTypes;
 use Cjmellor\Engageify\Exceptions\AmbiguousEngagementType;
+use Cjmellor\Engageify\Exceptions\InvalidEngagementEnum;
+use Cjmellor\Engageify\Exceptions\UnknownEngagementType;
+use Cjmellor\Engageify\Models\Engagement;
 use Cjmellor\Engageify\Support\TypeResolver;
 use Cjmellor\Engageify\Tests\Fixtures\Enums\Clap;
 use Cjmellor\Engageify\Tests\Fixtures\Enums\Mood;
@@ -69,4 +72,20 @@ test('a single enum (not wrapped in an array) still works', function (): void {
 
     expect($this->user->engagementCount(Reaction::Bookmark))->toBe(1)
         ->and($this->user->engagements()->first()->type)->toBe(Reaction::Bookmark);
+});
+
+test('writing an Engagement with an unknown verb value is rejected at write time', function (): void {
+    config(['engageify.types' => Reaction::class]);
+
+    expect(fn (): Engagement => $this->user->engagements()->create([
+        'user_id' => $this->user->getKey(),
+        'type' => 'definitely-not-a-verb',
+    ]))->toThrow(UnknownEngagementType::class);
+});
+
+test('registering a class that is not an EngagementType enum is rejected with a clear error', function (): void {
+    config(['engageify.types' => [Reaction::class, Engagement::class]]);
+
+    expect(fn () => TypeResolver::assertUniqueValues())
+        ->toThrow(InvalidEngagementEnum::class);
 });

--- a/tests/Fixtures/Enums/Clap.php
+++ b/tests/Fixtures/Enums/Clap.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cjmellor\Engageify\Tests\Fixtures\Enums;
+
+use Cjmellor\Engageify\Contracts\EngagementType;
+
+enum Clap: string implements EngagementType
+{
+    case Stars = 'stars';
+}


### PR DESCRIPTION
Closes #77.

## Problem

`engageify.types` accepted exactly **one** enum, and three places assumed it: `TypeResolver` (routing/validation/resolution), the `Engagement.type` cast, and `exclusiveGroupValues()`. An app that wanted to mix **rateable + exclusive + plain** verbs couldn't — a single PHP enum is all-rateable, all-exclusive, or all-plain (interfaces are implemented at the enum level). Consumers hit either `UnknownEngagementType` (the membership gate) or a cast `ValueError` (reading a value the configured enum doesn't define).

## Fix

Make `engageify.types` accept a **single enum or an array** (a registry). A verb is resolved from whichever registered enum defines it — no per-call config swapping.

- **`TypeResolver`** reads the config as one enum or a list; `resolve()`/`ensure()` search across all of them.
- **`Engagement.type`** now uses a new **`EngagementTypeCast`** that reconstructs a stored value to its case across the registry (kills the cast `ValueError` on mixed-verb requests).
- **`exclusiveGroupValues()`** spans the whole registry, so `netScore()` / `breakdown()` work for an exclusive enum that isn't first.
- **Boot-time guard:** registering enums that share a backed value throws a clear **`AmbiguousEngagementType`** rather than silently miscasting.
- **Backward compatible:** a single enum class still works unchanged.

```php
// config/engageify.php
'types' => [
    App\Enums\Stars::class,    // Rateable
    App\Enums\Vote::class,     // Exclusive + HasWeight
    App\Enums\Reaction::class, // plain
],

$film->engage(Stars::Rating, 4);
$film->engage(Vote::Up);
$film->like();
```

## Why a registry (and not self-describing rows)

The "purer" alternative — storing each engagement's enum class in a new column — sounds cleaner but is worse here: the counter table and **every ranking scope aggregate by the value string**, so they'd all need re-keying, and `netScore('vote')` / `breakdown('vote')` would change signature. Large blast radius for no real gain, since verb *values* are naturally unique. The registry is the smallest change that fully solves the general problem and keeps every documented API intact.

## Tests

Six new vertical-slice tests in `MixedVerbsTest` (mix engage, exclusive-not-first, collision guard, cross-enum hydrate, `like()` resolution, single-enum back-compat). Full suite: **123 passed, 100% code + type coverage**, Pint/Rector/larastan clean.

## Docs

Added a "Mixing several Verb enums" section to the README and a note on the `types` config key.