### PR TITLE
[2.x] Recompute hot_score when rebuilding counters (#79)

### DIFF
--- a/src/Models/EngagementCounter.php
+++ b/src/Models/EngagementCounter.php
@@ -42,12 +42,7 @@ class EngagementCounter extends Model
             if ((float) $valueDelta !== 0.0) {
                 $counter->refresh();
 
-                $sum = (float) $counter->sum_value;
-                $createdAt = $engageable->getAttribute($engageable->getCreatedAtColumn() ?? 'created_at');
-
-                $counter->hot_score = $sum !== 0.0 && $createdAt instanceof DateTimeInterface
-                    ? HotScore::calculate(score: $sum, createdAt: $createdAt)
-                    : 0;
+                $counter->hot_score = self::hotScoreFor(sum: (float) $counter->sum_value, engageable: $engageable);
                 $counter->save();
             }
         });
@@ -80,11 +75,33 @@ class EngagementCounter extends Model
                     'sum_value' => (float) $row->aggregate_sum,
                 ]);
             });
+
+        static::query()
+            ->where('sum_value', '!=', 0)
+            ->with('engagementable')
+            ->get()
+            ->each(function (self $counter): void {
+                $engageable = $counter->engagementable;
+
+                if ($engageable instanceof Model) {
+                    $counter->hot_score = self::hotScoreFor(sum: (float) $counter->sum_value, engageable: $engageable);
+                    $counter->save();
+                }
+            });
     }
 
     public function engagementable(): MorphTo
     {
         return $this->morphTo();
+    }
+
+    protected static function hotScoreFor(float $sum, Model $engageable): float|int
+    {
+        $createdAt = $engageable->getAttribute($engageable->getCreatedAtColumn() ?? 'created_at');
+
+        return $sum !== 0.0 && $createdAt instanceof DateTimeInterface
+            ? HotScore::calculate(score: $sum, createdAt: $createdAt)
+            : 0;
     }
 
     /**

--- a/tests/Feature/RecountCommandTest.php
+++ b/tests/Feature/RecountCommandTest.php
@@ -20,3 +20,25 @@ test('engageify:recount rebuilds the counters from the source rows', function ()
     expect($this->user->engagementCount(Vote::Up))->toBe(2)
         ->and($this->user->score(Vote::Up))->toBe(2.0);
 });
+
+test('engageify:recount recomputes hot_score so hot ranking survives a backfill', function (): void {
+    config(['engageify.types' => Vote::class, 'engageify.allow_multiple_engagements' => true]);
+
+    $this->actingAs($this->user);
+
+    foreach (range(1, 5) as $ignored) {
+        $this->user->engage(Vote::Up);
+    }
+
+    $find = fn (): EngagementCounter => EngagementCounter::query()
+        ->where('engagementable_id', $this->user->id)
+        ->where('type', Vote::Up->value)
+        ->firstOrFail();
+
+    $expected = (float) $find()->hot_score;
+
+    $this->artisan('engageify:recount')->assertSuccessful();
+
+    expect($expected)->toBeGreaterThan(0.0)
+        ->and((float) $find()->hot_score)->toBe($expected);
+});


### PR DESCRIPTION
Closes #79.

`EngagementCounter::rebuild()` (`engageify:recount`) rebuilt counters from the `engagements` table but never set `hot_score`, leaving it at the column default of `0`. Since `scopeHot()` orders by `hot_score`, the **documented v1→v2 backfill** silently broke `hot()` ranking until organic engage/disengage writes recomputed each row.

## Fix

`rebuild()` now runs a second pass that recomputes `hot_score` for every row with a non-zero `sum_value`, loading each engageable's `created_at` (eager-loaded) and reusing the exact same calculation as the write path. The shared logic is extracted into a `hotScoreFor()` helper so `record()` and `rebuild()` can't drift again.

## TDD

A failing-first test (`hot_score` was `0` after recount where `record()` had computed it) drove the fix. Binary / `sum_value = 0` rows still keep `hot_score = 0`.

`composer test`: **126 passed (231 assertions), 100% code + type coverage, Pint/Rector/larastan clean.**
