### PR TITLE
[2.x] Fix v2 release-blocking documentation gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,32 @@
 # Changelog
 
-## Unreleased (v2)
+## v2.0.0 - Unreleased
 
-### Breaking changes
+A major release adding ratings, view & impression tracking, Hot/Top ranking, weighted and custom engagement Verbs, and actor-side queries. **Read [`UPGRADING.md`](UPGRADING.md) before upgrading from v1** — there are breaking changes.
+
+### Added
+
+- **Custom & multiple Verb enums.** Define your own engagement Verbs by implementing the `EngagementType` contract; `engageify.types` now accepts a single enum or an array of enums.
+- **Weighted Verbs and engagement values** via a new `value` column on `engagements`, for score-based engagement.
+- **Exclusive groups** — vote-style Verbs where engaging with one option (e.g. `upvote`) automatically clears the others in its group.
+- **Ratings** on a configurable scale via the `Rateable` contract, with Bayesian-average ranking (`engageify.bayesian_minimum`).
+- **Hot / Top ranking** backed by a denormalised `engagement_counters` table, with a Reddit-style `hot()` score and time-windowed `top()` queries.
+- **Actor-side queries** — the `EngagesWith` trait and `withUserEngagement()` scope query and eager-load a user's own engagements without N+1s.
+- **View tracking** via the `HasViews` trait, plus opt-in time-windowed views backed by the `view_buckets` table.
+- **Impression tracking** — a signed-token viewport impression endpoint, an `@impression` Blade directive, and an optional injectable browser tracker (`engageify.impressions.*`).
+- **`engageify:recount` command** to (re)build the engagement counters from the `engagements` table.
+- **Generic `Engaged` and `Disengaged` events** carrying the actor, engageable, and Verb (and, for `Engaged`, the engagement row).
+
+### Changed
 
 - **Counts and scores are now read from a denormalised `engagement_counters` table** instead of being counted from the `engagements` table on the fly. Existing v1 installs **must run `php artisan engageify:recount` once** (after publishing and running the new migrations) to backfill the counters — until then, counts, scores, and ranking queries read as `0` for pre-existing engagements. See [Upgrading from v1](README.md#upgrading-from-v1) and [`UPGRADING.md`](UPGRADING.md).
-- **The in-memory cache layer has been removed.** The `allow_caching` and `cache_duration` config keys no longer exist; counts are kept fresh inside the same transaction as each engage/disengage, so there is nothing to invalidate.
+- **Raised the minimum requirements to PHP `^8.3` and Laravel `^12.0|^13.0`.**
+
+### Removed
+
+- **The `Engageify` facade and its `Engageify` alias** — engagement is driven through the `HasEngagements` trait on your models.
+- **The five reaction-specific events** (`ModelLikedEvent`, `ModelDislikedEvent`, `ModelUpvotedEvent`, `ModelDownvotedEvent`, `ModelDisengagedEvent`) — replaced by the generic `Engaged` / `Disengaged` events.
+- **The in-memory cache layer.** The `allow_caching` and `cache_duration` config keys no longer exist; counts are kept fresh inside the same transaction as each engage/disengage, so there is nothing to invalidate.
 
 ## v0.0.1 - 2023-10-08
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![GitHub Tests Action Status](https://img.shields.io/github/actions/workflow/status/cjmellor/engageify/run-pest.yml?branch=main&label=tests&style=for-the-badge&color=rgb%28134%20239%20128%29)](https://github.com/cjmellor/engageify/actions/workflows/run-pest.yml?query=branch%3Amain)
 [![Total Downloads](https://img.shields.io/packagist/dt/cjmellor/engageify.svg?color=rgb%28249%20115%2022%29&style=for-the-badge)](https://packagist.org/packages/cjmellor/engageify)
 ![Packagist PHP Version](https://img.shields.io/packagist/dependency-v/cjmellor/engageify/php?color=rgb%28165%20180%20252%29&logo=php&logoColor=rgb%28165%20180%20252%29&style=for-the-badge)
-![Laravel Version](https://img.shields.io/badge/laravel-^10-rgb(235%2068%2050)?style=for-the-badge&logo=laravel)
+![Laravel Version](https://img.shields.io/badge/laravel-12.x%20%7C%2013.x-rgb(235%2068%2050)?style=for-the-badge&logo=laravel)
 
 Engageify is a Laravel package that allows you to integrate engagement features like user reactions (likes, upvotes) to your models.
 
@@ -14,6 +14,13 @@ You can install the package via composer:
 
 ```bash
 composer require cjmellor/engageify
+```
+
+Publish and run the migrations. This creates the `engagements`, `engagement_counters`, and `view_buckets` tables the package needs:
+
+```bash
+php artisan vendor:publish --tag="engageify-migrations"
+php artisan migrate
 ```
 
 Publish the config file (optional)
@@ -45,11 +52,13 @@ v2 changes how engagement counts are stored and read. **If you are upgrading an 
 
 > **Heads-up:** the in-memory cache layer from v1 has been removed. Counts are kept in step inside the same database transaction as every engage/disengage, so they are always fresh — the `allow_caching` / `cache_duration` config keys no longer exist, and there is nothing to invalidate.
 
+v2 also raises the minimum requirements to **PHP 8.3** and **Laravel 12**, removes the `Engageify` facade, and replaces the five reaction-specific events with two generic ones. If you depended on any of those, see [`UPGRADING.md`](UPGRADING.md) before upgrading.
+
 See [`UPGRADING.md`](UPGRADING.md) for the full checklist.
 
 ## Usage
 
-For Models you wish to have engagement features (likes/upvotes), use the Engageable trait.
+For Models you wish to have engagement features (likes/upvotes), use the `HasEngagements` trait.
 
 ```php
 <?php
@@ -86,7 +95,7 @@ A generic `Engaged` event is dispatched on each reaction, carrying the actor, th
 
 #### Multiple Reactions
 
-By default, a User can only react once to a Model. If you wish to allow multiple reactions, you can do so by setting the `engagement.allow_multiple_engagements` config value to `true`.
+By default, a User can only react once to a Model. If you wish to allow multiple reactions, you can do so by setting the `engageify.allow_multiple_engagements` config value to `true` (or the `ENGAGEIFY_MULTIPLE_ENGAGEMENTS` environment variable).
 
 ### Custom Engagement Types
 
@@ -285,7 +294,7 @@ $comment->unlike();
 
 When a Model is "unliked", a generic `Disengaged` event is fired.
 
-There is also a convenient `toggle()` method that will toggle between "like" and "unlike".
+There is also a convenient `toggleLike()` method that will toggle between "like" and "unlike".
 
 ```php
 $comment->toggleLike();
@@ -380,7 +389,7 @@ Instead of just fetching the amount of engagements, you can fetch the Users who 
 
 ```php
 $post->likes(showUsers: true);
-````
+```
 
 This will return a Collection of Users who liked the Model.
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -35,6 +35,26 @@ php artisan engageify:recount
 pre-existing engagements.** The engagement rows themselves are untouched — only
 the counter table needs building.
 
+### Other breaking changes
+
+- **Raised minimum requirements.** v2 requires **PHP `^8.3`** and **Laravel `^12.0|^13.0`** (Laravel 10/11 and PHP 8.2 are no longer supported). Bump your own constraints before upgrading.
+
+- **The `Engageify` facade has been removed.** The `Cjmellor\Engageify\Facades\Engageify` class and its `Engageify` alias no longer exist. Engagement is driven entirely through the `HasEngagements` trait on your models (`$model->like()`, `$model->engage(...)`, etc.) — replace any facade calls with the equivalent model methods.
+
+- **The five reaction-specific events were replaced by two generic events.** `ModelLikedEvent`, `ModelDislikedEvent`, `ModelUpvotedEvent`, `ModelDownvotedEvent`, and `ModelDisengagedEvent` are gone. Every engage now fires `Cjmellor\Engageify\Events\Engaged` and every disengage fires `Cjmellor\Engageify\Events\Disengaged`. Update your listeners to subscribe to the new events and branch on the payload:
+
+  ```php
+  // Engaged: public Model $actor, Model $engageable, EngagementType $type, Engagement $engagement
+  // Disengaged: public Model $actor, Model $engageable, EngagementType $type
+
+  public function handle(Engaged $event): void
+  {
+      if ($event->type === EngagementTypes::Like) {
+          // ... what ModelLikedEvent used to do
+      }
+  }
+  ```
+
 ### Notes
 
 - **The cache layer has been removed.** The `allow_caching` and `cache_duration`


### PR DESCRIPTION
Clears the documentation release-blockers found by the v2 release audit. Docs-only — `composer test` stays **125 green / 100% coverage**.

## README
- Add the missing migration step (publish + `migrate`) to Installation — a fresh install otherwise never creates the tables.
- Fix the Laravel version badge (`^10` → `12.x | 13.x`).
- Fix the `engagement.` → `engageify.allow_multiple_engagements` config prefix typo (the wrong key silently no-ops).
- Note the other v1→v2 breaking changes in the upgrade section.
- Doc-rot: `HasEngagements` trait (was "Engageable"), `toggleLike()` (was `toggle()`), and a stray quadruple-backtick fence.

## UPGRADING.md
Document the previously-undocumented breaking changes: raised **PHP `^8.3` / Laravel `^12|^13`** floors, removed `Engageify` facade + alias, and the five reaction events replaced by generic `Engaged`/`Disengaged` (with a listener-migration snippet).

## CHANGELOG.md
Expand the v2 entry into Added / Changed / Removed covering the full feature surface and all breaking changes; head it `v2.0.0`.

## Removed
Delete the empty `UPGRADE.md` stub that shadowed `UPGRADING.md`.
