### PR TITLE
Allow engagements to name an explicit actor

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,21 @@ $film->like();
 
 The registry is validated **once at boot**: every entry must be a backed enum implementing `EngagementType` (otherwise `InvalidEngagementEnum`), and their values must be **collectively unique** (otherwise `AmbiguousEngagementType`). Because the check runs at boot, swapping `engageify.types` at runtime bypasses it.
 
+### Engaging as a specific actor
+
+By default the engaging actor is `auth()->user()`. Applications where the authenticated principal is not the model that owns engagements — multi-tenant setups, impersonation, queued jobs, seeders — can pass the actor explicitly:
+
+```php
+$post->engage(Reaction::Bookmark, actor: $user);
+$post->disengage(Reaction::Bookmark, actor: $user);
+
+$post->like(actor: $user);
+$post->unlike(actor: $user);
+$post->toggleLike(actor: $user);
+```
+
+The actor is written to `engagements.user_id`, scopes the "already engaged" guard and the exclusive-group flip, and is the `actor` carried by the `Engaged` and `Disengaged` events. Omitting it keeps the existing behaviour; if there is no actor and nobody is authenticated, a `UserCannotEngageException` is thrown.
+
 ### Weighted Verbs & Engagement Values
 
 Engagements can carry an optional numeric **value** (a nullable signed decimal column). A Verb opts in by implementing `Cjmellor\Engageify\Contracts\HasWeight`, which derives a fixed weight per case — for example an upvote is `+1` and a downvote `-1`:
@@ -383,6 +398,8 @@ $feed->first()->is_engaged; // true/false — no extra query per row
 
 If more than one engagement row exists for the same user, target and Verb (e.g. seeded or imported data), the attached `engagement_value` is taken from the **most recent** engagement, so the value is deterministic across database engines.
 
+> This scope's parameter is named `$user` for backwards compatibility; it takes the same model you would pass as `actor:` to `engage()`.
+
 #### Fetch Users' Who Engaged
 
 Instead of just fetching the amount of engagements, you can fetch the Users who engaged.
@@ -463,7 +480,7 @@ While injection is off, the middleware is **not added to the global HTTP stack a
 
 ## Events
 
-Two generic events are dispatched for every engagement, regardless of the Verb.
+Two generic events are dispatched for every engagement, regardless of the Verb. `$actor` is whoever was passed to `engage()`/`disengage()`, falling back to the authenticated user.
 
 `Cjmellor\Engageify\Events\Engaged` is dispatched when a Model is engaged:
 

--- a/src/Concerns/HasEngagements.php
+++ b/src/Concerns/HasEngagements.php
@@ -42,36 +42,36 @@ trait HasEngagements
         return $this->morphMany(related: EngagementCounter::class, name: 'engagementable');
     }
 
-    public function like(): Model
+    public function like(?Model $actor = null): Model
     {
-        return $this->engage(type: TypeResolver::resolve(value: EngagementTypes::Like->value));
+        return $this->engage(type: TypeResolver::resolve(value: EngagementTypes::Like->value), actor: $actor);
     }
 
-    public function dislike(): Model
+    public function dislike(?Model $actor = null): Model
     {
-        return $this->engage(type: TypeResolver::resolve(value: EngagementTypes::Dislike->value));
+        return $this->engage(type: TypeResolver::resolve(value: EngagementTypes::Dislike->value), actor: $actor);
     }
 
-    public function upvote(): Model
+    public function upvote(?Model $actor = null): Model
     {
-        return $this->engage(type: TypeResolver::resolve(value: EngagementTypes::Upvote->value));
+        return $this->engage(type: TypeResolver::resolve(value: EngagementTypes::Upvote->value), actor: $actor);
     }
 
-    public function downvote(): Model
+    public function downvote(?Model $actor = null): Model
     {
-        return $this->engage(type: TypeResolver::resolve(value: EngagementTypes::Downvote->value));
+        return $this->engage(type: TypeResolver::resolve(value: EngagementTypes::Downvote->value), actor: $actor);
     }
 
-    public function unlike(): void
+    public function unlike(?Model $actor = null): void
     {
-        $this->disengage(type: TypeResolver::resolve(value: EngagementTypes::Like->value));
+        $this->disengage(type: TypeResolver::resolve(value: EngagementTypes::Like->value), actor: $actor);
     }
 
-    public function toggleLike(): void
+    public function toggleLike(?Model $actor = null): void
     {
-        $this->hasEngagedWithType(type: TypeResolver::resolve(value: EngagementTypes::Like->value))
-            ? $this->unlike()
-            : $this->like();
+        $this->hasEngagedWithType(type: TypeResolver::resolve(value: EngagementTypes::Like->value), actor: $actor)
+            ? $this->unlike(actor: $actor)
+            : $this->like(actor: $actor);
     }
 
     public function likes(bool $showUsers = false): Collection|int
@@ -94,36 +94,38 @@ trait HasEngagements
         return $this->getEngagementCount(type: TypeResolver::resolve(value: EngagementTypes::Downvote->value), showUsers: $showUsers);
     }
 
-    public function engage(EngagementType $type, int|float|null $value = null): Model
+    public function engage(EngagementType $type, int|float|null $value = null, ?Model $actor = null): Model
     {
         $type = TypeResolver::ensure(type: $type);
 
         if ($type instanceof Exclusive) {
-            return $this->engageExclusive(type: $type, value: $value);
+            return $this->engageExclusive(type: $type, value: $value, actor: $actor);
         }
 
         if ($type instanceof Rateable) {
-            return $this->rate(type: $type, value: $value);
+            return $this->rate(type: $type, value: $value, actor: $actor);
         }
 
+        $actor = $this->resolveActor(actor: $actor);
+
         throw_if(
-            config(key: 'engageify.allow_multiple_engagements') === false && $this->hasEngagedWithType(type: $type),
+            config(key: 'engageify.allow_multiple_engagements') === false && $this->hasEngagedWithType(type: $type, actor: $actor),
             UserCannotEngageException::class,
             'This model has already been engaged'
         );
 
         $resolved = $this->resolveEngagementValue(type: $type, value: $value);
 
-        return DB::transaction(function () use ($type, $resolved): Engagement {
+        return DB::transaction(function () use ($type, $resolved, $actor): Engagement {
             $engagement = $this->engagements()->create([
-                'user_id' => auth()->id(),
+                'user_id' => $actor->getKey(),
                 'type' => $type,
                 'value' => $resolved,
             ]);
 
             EngagementCounter::record(engageable: $this, type: $type->value, countDelta: 1, valueDelta: (float) ($resolved ?? 0));
 
-            event(new Engaged(actor: auth()->user(), engageable: $this, type: $type, engagement: $engagement));
+            event(new Engaged(actor: $actor, engageable: $this, type: $type, engagement: $engagement));
 
             return $engagement;
         });
@@ -149,16 +151,18 @@ trait HasEngagements
         return $count === 0 ? 0.0 : $this->counterSum(type: $type) / $count;
     }
 
-    public function disengage(EngagementType $type): void
+    public function disengage(EngagementType $type, ?Model $actor = null): void
     {
-        DB::transaction(function () use ($type): void {
+        $actor = $this->resolveActor(actor: $actor);
+
+        DB::transaction(function () use ($type, $actor): void {
             $engagements = $this->engagements()
-                ->whereUserId(auth()->id())
+                ->whereUserId($actor->getKey())
                 ->whereType($type)
                 ->get();
 
             if ($engagements->isNotEmpty()) {
-                $this->engagements()->whereUserId(auth()->id())->whereType($type)->delete();
+                $this->engagements()->whereUserId($actor->getKey())->whereType($type)->delete();
 
                 EngagementCounter::record(
                     engageable: $this,
@@ -168,7 +172,7 @@ trait HasEngagements
                 );
             }
 
-            event(new Disengaged(actor: auth()->user(), engageable: $this, type: $type));
+            event(new Disengaged(actor: $actor, engageable: $this, type: $type));
         });
     }
 
@@ -405,27 +409,31 @@ trait HasEngagements
             ->where('user_id', $userKey);
     }
 
-    protected function engageExclusive(EngagementType&Exclusive $type, int|float|null $value): Engagement
+    protected function engageExclusive(EngagementType&Exclusive $type, int|float|null $value, ?Model $actor = null): Engagement
     {
-        return DB::transaction(fn (): Engagement => $this->flipExclusive(type: $type, value: $value));
+        $actor = $this->resolveActor(actor: $actor);
+
+        return DB::transaction(fn (): Engagement => $this->flipExclusive(type: $type, value: $value, actor: $actor));
     }
 
-    protected function flipExclusive(EngagementType&Exclusive $type, int|float|null $value): Engagement
+    protected function flipExclusive(EngagementType&Exclusive $type, int|float|null $value, ?Model $actor = null): Engagement
     {
+        $actor = $this->resolveActor(actor: $actor);
+
         $existing = $this->engagements()
-            ->whereUserId(auth()->id())
+            ->whereUserId($actor->getKey())
             ->whereIn('type', $this->exclusiveGroupValues(group: $type->group()))
             ->lockForUpdate()
             ->get();
 
         $active = $existing->first(fn (Engagement $engagement): bool => $engagement->type === $type);
 
-        $existing->each(function (Engagement $engagement): void {
+        $existing->each(function (Engagement $engagement) use ($actor): void {
             $engagement->delete();
 
             EngagementCounter::record(engageable: $this, type: $engagement->type->value, countDelta: -1, valueDelta: -(float) $engagement->value);
 
-            event(new Disengaged(actor: auth()->user(), engageable: $this, type: $engagement->type));
+            event(new Disengaged(actor: $actor, engageable: $this, type: $engagement->type));
         });
 
         if ($active instanceof Engagement) {
@@ -435,14 +443,14 @@ trait HasEngagements
         $resolved = $this->resolveEngagementValue(type: $type, value: $value);
 
         $engagement = $this->engagements()->create([
-            'user_id' => auth()->id(),
+            'user_id' => $actor->getKey(),
             'type' => $type,
             'value' => $resolved,
         ]);
 
         EngagementCounter::record(engageable: $this, type: $type->value, countDelta: 1, valueDelta: (float) ($resolved ?? 0));
 
-        event(new Engaged(actor: auth()->user(), engageable: $this, type: $type, engagement: $engagement));
+        event(new Engaged(actor: $actor, engageable: $this, type: $type, engagement: $engagement));
 
         return $engagement;
     }
@@ -460,15 +468,17 @@ trait HasEngagements
             ->all();
     }
 
-    protected function rate(EngagementType&Rateable $type, int|float|null $value): Engagement
+    protected function rate(EngagementType&Rateable $type, int|float|null $value, ?Model $actor = null): Engagement
     {
         throw_if($value === null, InvalidRatingException::valueRequired(type: $type));
 
         $validated = RatingScale::validate(type: $type, value: $value);
 
-        return DB::transaction(function () use ($type, $validated): Engagement {
+        $actor = $this->resolveActor(actor: $actor);
+
+        return DB::transaction(function () use ($type, $validated, $actor): Engagement {
             $existing = $this->engagements()
-                ->whereUserId(auth()->id())
+                ->whereUserId($actor->getKey())
                 ->whereType($type)
                 ->lockForUpdate()
                 ->first();
@@ -483,7 +493,7 @@ trait HasEngagements
                 $engagement = $existing;
             } else {
                 $engagement = $this->engagements()->create([
-                    'user_id' => auth()->id(),
+                    'user_id' => $actor->getKey(),
                     'type' => $type,
                     'value' => $validated,
                 ]);
@@ -491,7 +501,7 @@ trait HasEngagements
                 EngagementCounter::record(engageable: $this, type: $type->value, countDelta: 1, valueDelta: $validated);
             }
 
-            event(new Engaged(actor: auth()->user(), engageable: $this, type: $type, engagement: $engagement));
+            event(new Engaged(actor: $actor, engageable: $this, type: $type, engagement: $engagement));
 
             return $engagement;
         });
@@ -509,12 +519,21 @@ trait HasEngagements
         return $type instanceof HasWeight || $type instanceof Rateable;
     }
 
-    protected function hasEngagedWithType(EngagementType $type): bool
+    protected function hasEngagedWithType(EngagementType $type, ?Model $actor = null): bool
     {
         return $this->engagements()
-            ->whereUserId(auth()->id())
+            ->whereUserId($this->resolveActor(actor: $actor)->getKey())
             ->whereType($type)
             ->exists();
+    }
+
+    protected function resolveActor(?Model $actor = null): Model
+    {
+        $actor ??= auth()->user();
+
+        throw_unless($actor instanceof Model, UserCannotEngageException::class, 'No actor was given and no user is authenticated');
+
+        return $actor;
     }
 
     protected function getEngagementCount(EngagementType $type, bool $showUsers = false): Collection|int

--- a/tests/Concerns/ExplicitActorTest.php
+++ b/tests/Concerns/ExplicitActorTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+use Cjmellor\Engageify\Enums\EngagementTypes;
+use Cjmellor\Engageify\Events\Disengaged;
+use Cjmellor\Engageify\Events\Engaged;
+use Cjmellor\Engageify\Exceptions\UserCannotEngageException;
+use Cjmellor\Engageify\Models\Engagement;
+use Cjmellor\Engageify\Tests\Fixtures\Enums\Ballot;
+use Cjmellor\Engageify\Tests\Fixtures\Enums\Rating;
+use Cjmellor\Engageify\Tests\Fixtures\User;
+use Illuminate\Support\Facades\Event;
+
+beforeEach(function (): void {
+    $this->actor = User::factory()->createOne();
+});
+
+test(description: 'an explicit actor is written to the engagement, not the authenticated user', closure: function (string $type): void {
+    $this->actingAs($this->user);
+
+    $this->user->{$type}(actor: $this->actor);
+
+    $this->assertDatabaseHas(table: Engagement::class, data: [
+        'engagementable_id' => $this->user->id,
+        'engagementable_type' => User::class,
+        'user_id' => $this->actor->id,
+        'type' => $type,
+    ]);
+})->with([
+    EngagementTypes::Like->value,
+    EngagementTypes::Dislike->value,
+    EngagementTypes::Upvote->value,
+    EngagementTypes::Downvote->value,
+]);
+
+test(description: 'an explicit actor can engage with no authenticated user at all', closure: function (): void {
+    $this->user->engage(type: EngagementTypes::Like, actor: $this->actor);
+
+    $this->assertDatabaseHas(table: Engagement::class, data: [
+        'user_id' => $this->actor->id,
+        'type' => EngagementTypes::Like->value,
+    ]);
+});
+
+test(description: 'engaging without an actor and without an authenticated user throws')
+    ->defer(fn () => $this->user->engage(type: EngagementTypes::Like))
+    ->throws(exception: UserCannotEngageException::class, exceptionMessage: 'No actor was given and no user is authenticated');
+
+test(description: 'disengaging without an actor and without an authenticated user throws')
+    ->defer(fn () => $this->user->disengage(type: EngagementTypes::Like))
+    ->throws(exception: UserCannotEngageException::class);
+
+test(description: 'events carry the explicit actor', closure: function (): void {
+    Event::fake();
+
+    $this->actingAs($this->user);
+
+    $this->user->like(actor: $this->actor);
+    $this->user->unlike(actor: $this->actor);
+
+    Event::assertDispatched(event: Engaged::class, callback: fn (Engaged $event): bool => $event->actor->is($this->actor));
+    Event::assertDispatched(event: Disengaged::class, callback: fn (Disengaged $event): bool => $event->actor->is($this->actor));
+});
+
+test(description: 'disengaging only removes the given actor\'s engagements', closure: function (): void {
+    config(['engageify.allow_multiple_engagements' => false]);
+
+    $this->user->like(actor: $this->actor);
+    $this->user->like(actor: $this->user);
+
+    $this->user->unlike(actor: $this->actor);
+
+    expect($this->user->engagements()->pluck('user_id')->all())->toBe([$this->user->id]);
+});
+
+test(description: 'the per-actor engagement guard is scoped to the actor', closure: function (): void {
+    config(['engageify.allow_multiple_engagements' => false]);
+
+    $this->user->like(actor: $this->actor);
+    $this->user->like(actor: $this->user);
+
+    expect($this->user->engagements()->count())->toBe(2);
+});
+
+test(description: 'toggleLike honours the explicit actor', closure: function (): void {
+    $this->user->toggleLike(actor: $this->actor);
+
+    expect($this->user->engagements()->count())->toBe(1);
+
+    $this->user->toggleLike(actor: $this->actor);
+
+    expect($this->user->engagements()->count())->toBe(0);
+});
+
+test(description: 'exclusive engagements flip per actor', closure: function (): void {
+    config(['engageify.types' => Ballot::class]);
+
+    $this->user->engage(type: Ballot::Down, actor: $this->actor);
+    $this->user->engage(type: Ballot::Down, actor: $this->user);
+    $this->user->engage(type: Ballot::Up, actor: $this->actor);
+
+    expect($this->user->engagements()->whereUserId($this->actor->id)->pluck('type')->all())->toBe([Ballot::Up])
+        ->and($this->user->engagements()->whereUserId($this->user->id)->pluck('type')->all())->toBe([Ballot::Down]);
+});
+
+test(description: 'exclusive engagements dispatch events carrying the explicit actor', closure: function (): void {
+    config(['engageify.types' => Ballot::class]);
+
+    Event::fake();
+
+    $this->user->engage(type: Ballot::Down, actor: $this->actor);
+    $this->user->engage(type: Ballot::Up, actor: $this->actor);
+
+    Event::assertDispatched(event: Disengaged::class, callback: fn (Disengaged $event): bool => $event->actor->is($this->actor));
+    Event::assertDispatched(event: Engaged::class, callback: fn (Engaged $event): bool => $event->actor->is($this->actor));
+});
+
+test(description: 'ratings are recorded and updated per actor', closure: function (): void {
+    config(['engageify.types' => Rating::class]);
+
+    $this->user->engage(type: Rating::Stars, value: 4, actor: $this->actor);
+    $this->user->engage(type: Rating::Stars, value: 2, actor: $this->user);
+    $this->user->engage(type: Rating::Stars, value: 5, actor: $this->actor);
+
+    expect($this->user->engagements()->whereUserId($this->actor->id)->count())->toBe(1)
+        ->and((float) $this->user->engagements()->whereUserId($this->actor->id)->value('value'))->toBe(5.0)
+        ->and((float) $this->user->engagements()->whereUserId($this->user->id)->value('value'))->toBe(2.0);
+});
+
+test(description: 'ratings dispatch the Engaged event carrying the explicit actor', closure: function (): void {
+    config(['engageify.types' => Rating::class]);
+
+    Event::fake();
+
+    $this->user->engage(type: Rating::Stars, value: 4, actor: $this->actor);
+
+    Event::assertDispatched(event: Engaged::class, callback: fn (Engaged $event): bool => $event->actor->is($this->actor));
+});


### PR DESCRIPTION
Engaging and disengaging resolved the actor from `auth()` alone, so applications whose authenticated principal is not the model owning engagements — multi-tenant setups, impersonation, queued jobs, seeders — couldn't use the trait's mutators at all.

`engage()`, `disengage()` and the convenience verbs (`like`, `dislike`, `upvote`, `downvote`, `unlike`, `toggleLike`) now take an optional trailing `actor`, defaulting to the authenticated user. The resolved actor is what's written to `user_id`, what scopes the duplicate-engagement guard, the exclusive-group flip and the rating upsert, and what the `Engaged`/`Disengaged` events carry.

That last part is a correctness fix even on the default path: `flipExclusive()` deleted rows keyed on `auth()->id()` while the events reported `auth()->user()`. With no actor and nobody authenticated, a `UserCannotEngageException` is now thrown with a clear message instead of failing deeper in the stack.

```php
$post->engage(Reaction::Bookmark, actor: $user);
$post->like(actor: $user);
$post->unlike(actor: $user);
```

New optional trailing parameter throughout, so no BC break — suitable for a minor release.

`withUserEngagement()`'s existing parameter stays named `$user` rather than being renamed to `$actor`, since renaming it would break named-argument callers; the README notes it takes the same model.

Possible follow-ups, deliberately out of scope here: a config-level actor resolver closure, an idempotent `engageOnce()`, and a unique index on (engageable, user, type) when `allow_multiple_engagements` is false.

## Testing

15 new tests covering explicit-actor writes, per-actor disengage and duplicate guards, per-actor exclusive flips and rating upserts, event payloads, and the no-actor/no-auth failure. Full `composer test` green: pint, rector dry-run, 100% type coverage, phpstan clean, 117 tests at exactly 100% code coverage.
