### PR TITLE
fix: Correct disengage event emission and the engage uniqueness guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ The "like" reaction has some additional functionality. A "like" can be "unliked"
 $comment->unlike();
 ```
 
-When a Model is "unliked", a generic `Disengaged` event is fired.
+When a Model is "unliked", a generic `Disengaged` event is fired. Unliking something that was never liked is a no-op — nothing is deleted, the counters are untouched, and no event is dispatched.
 
 There is also a convenient `toggleLike()` method that will toggle between "like" and "unlike".
 
@@ -491,7 +491,7 @@ public EngagementType $type,
 public Engagement $engagement,
 ```
 
-`Cjmellor\Engageify\Events\Disengaged` is dispatched when an engagement is removed (e.g. an "unlike"):
+`Cjmellor\Engageify\Events\Disengaged` is dispatched when an engagement is actually removed (e.g. an "unlike"). It is not dispatched when there was nothing to remove, so a listener can treat every event as a real deletion:
 
 ```php
 public Model $actor,

--- a/src/Concerns/HasEngagements.php
+++ b/src/Concerns/HasEngagements.php
@@ -108,15 +108,15 @@ trait HasEngagements
 
         $actor = $this->resolveActor(actor: $actor);
 
-        throw_if(
-            config(key: 'engageify.allow_multiple_engagements') === false && $this->hasEngagedWithType(type: $type, actor: $actor),
-            UserCannotEngageException::class,
-            'This model has already been engaged'
-        );
-
         $resolved = $this->resolveEngagementValue(type: $type, value: $value);
 
         return DB::transaction(function () use ($type, $resolved, $actor): Engagement {
+            throw_if(
+                config(key: 'engageify.allow_multiple_engagements') === false && $this->hasEngagedWithType(type: $type, actor: $actor, lock: true),
+                UserCannotEngageException::class,
+                'This model has already been engaged'
+            );
+
             $engagement = $this->engagements()->create([
                 'user_id' => $actor->getKey(),
                 'type' => $type,
@@ -161,16 +161,18 @@ trait HasEngagements
                 ->whereType($type)
                 ->get();
 
-            if ($engagements->isNotEmpty()) {
-                $this->engagements()->whereUserId($actor->getKey())->whereType($type)->delete();
-
-                EngagementCounter::record(
-                    engageable: $this,
-                    type: $type->value,
-                    countDelta: -$engagements->count(),
-                    valueDelta: -(float) $engagements->sum(fn (Engagement $engagement): float => (float) $engagement->value),
-                );
+            if ($engagements->isEmpty()) {
+                return;
             }
+
+            $this->engagements()->whereUserId($actor->getKey())->whereType($type)->delete();
+
+            EngagementCounter::record(
+                engageable: $this,
+                type: $type->value,
+                countDelta: -$engagements->count(),
+                valueDelta: -(float) $engagements->sum(fn (Engagement $engagement): float => (float) $engagement->value),
+            );
 
             event(new Disengaged(actor: $actor, engageable: $this, type: $type));
         });
@@ -519,11 +521,12 @@ trait HasEngagements
         return $type instanceof HasWeight || $type instanceof Rateable;
     }
 
-    protected function hasEngagedWithType(EngagementType $type, ?Model $actor = null): bool
+    protected function hasEngagedWithType(EngagementType $type, ?Model $actor = null, bool $lock = false): bool
     {
         return $this->engagements()
             ->whereUserId($this->resolveActor(actor: $actor)->getKey())
             ->whereType($type)
+            ->when($lock, fn (Builder $query): Builder => $query->lockForUpdate())
             ->exists();
     }
 

--- a/tests/Concerns/EngagementCounterTest.php
+++ b/tests/Concerns/EngagementCounterTest.php
@@ -93,12 +93,12 @@ test('reads return zero for a Verb with no engagements', function (): void {
         ->and($this->user->averageOf(Vote::Up))->toBe(0.0);
 });
 
-test('disengaging when nothing is engaged fires Disengaged and leaves the counter untouched', function (): void {
+test('disengaging when nothing is engaged fires no event and leaves the counter untouched', function (): void {
     Event::fake();
 
     $this->user->unlike();
 
-    Event::assertDispatched(Disengaged::class);
+    Event::assertNotDispatched(Disengaged::class);
 
     expect($this->user->likes())->toBe(0);
 


### PR DESCRIPTION
Two correctness bugs in `HasEngagements`, both found while integrating the package downstream.

### Phantom `Disengaged` event

`disengage()` guarded the delete and the counter adjustment behind a non-empty check, but dispatched `Disengaged` unconditionally — so calling `unlike()` on a model that was never engaged fired an event for a deletion that never happened. `flipExclusive()` only emits the event for rows it actually deleted, so the package contradicted itself. It now early-returns when nothing matched.

This matters to consumers wiring notifications to these events: a repeat `DELETE` would emit a spurious one.

### Check-then-insert race in `engage()`

With `allow_multiple_engagements = false` the guard was an `exists()` query outside the transaction, and the migration ships no unique index, so two concurrent requests could both pass the guard, both insert, and double-count the counter. The check now runs inside the transaction under `lockForUpdate()`, matching the pattern `rate()` and `flipExclusive()` already use.

A unique index on `(engagementable_type, engagementable_id, user_id, type)` was considered and rejected: `allow_multiple_engagements = true` is supported and legitimately produces duplicate rows, so the index would break that mode.

Caveat worth recording: gap-locking prevents phantom inserts on MySQL/InnoDB, and SQLite serializes writes, but Postgres does not gap-lock a `SELECT … FOR UPDATE` that matches zero rows. This closes the window on MySQL/SQLite and narrows it on Postgres.

### Tests

One existing test codified the phantom-event bug (`EngagementCounterTest`) — it asserted `Disengaged` *is* dispatched on a no-op disengage. Inverted to `assertNotDispatched` and retitled; its counter assertions were already correct.

`composer test` green: Pint, Rector, PHPStan, 100% type coverage, 100% line coverage, 141 tests / 253 assertions.